### PR TITLE
Enable Travis testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: node_js
 addons:
   chrome: stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
+addons:
+  chrome: stable
 node_js:
   - "7"
   - "node"
 before_install:
-  - export CHROME_BIN=chromium-browser
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
+  - google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,7 @@ language: node_js
 node_js:
   - "7"
   - "node"
+before_install:
+  - export CHROME_BIN=chromium-browser
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 dist: trusty
+sudo: required
 language: node_js
 addons:
   chrome: stable
 node_js:
   - "7"
   - "node"
-before_install:
-  - google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost

--- a/bower.json
+++ b/bower.json
@@ -14,7 +14,7 @@
     "tests"
   ],
   "dependencies": {
-    "hello": "git@github.com:dan-silver/hello.js.git#master",
+    "hello": "https://github.com/dan-silver/hello.js.git",
     "office-ui-fabric-js": "^1.4.0"
   },
   "devDependencies": {

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -28,6 +28,17 @@ module.exports = function(config) {
       Chrome_travis_ci: {
         base: 'Chrome',
         flags: ['--no-sandbox']
+      },
+      ChromeHeadless: {
+        base: 'Chrome',
+        flags: [
+          '--no-sandbox',
+          // See https://chromium.googlesource.com/chromium/src/+/lkgr/headless/README.md
+          '--headless',
+          '--disable-gpu',
+          // Without a remote debugging port, Google Chrome exits immediately.
+          ' --remote-debugging-port=9222',
+        ]
       }
     },
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -7,7 +7,7 @@ module.exports = function(config) {
   var testingBase    = 'testing/'; // transpiled test JS and map files
   var testingSrcBase = 'testing/'; // test source TS files
 
-  config.set({
+  var configuration = {
     basePath: '',
     frameworks: ['jasmine'],
 
@@ -96,5 +96,12 @@ module.exports = function(config) {
     autoWatch: true,
     browsers: ['Chrome'],
     singleRun: false
-  })
+  }
+
+  if (process.env.TRAVIS) {
+      configuration.browsers = ['Chrome_travis_ci'];
+  }
+
+  config.set(configuration);
+
 }

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -109,10 +109,6 @@ module.exports = function(config) {
     singleRun: false
   }
 
-  if (process.env.TRAVIS) {
-      configuration.browsers = ['Chrome_travis_ci'];
-  }
-
   config.set(configuration);
 
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start": "concurrently \"npm run build:watch\" \"npm run serve\"",
     "serve": "lite-server -c=bs-config.json",
     "postinstall": "bower install",
-    "test": "npm run build && karma start karma.conf.js --single-run",
+    "test": "npm run build && karma start karma.conf.js --single-run --browsers ChromeHeadless",
     "test:watch": "concurrently \"npm run build:watch\" \"karma start karma.conf.js\"",
 
     "rollup": "rollup -c rollup-config.js"
@@ -44,8 +44,8 @@
     "angular-in-memory-web-api": "^0.3.0",
     "bower": "^1.8.0",
     "core-js": "^2.4.1",
-    "karma": "^1.6.0",
-    "karma-chrome-launcher": "^2.0.0",
+    "karma": "^1.7.0",
+    "karma-chrome-launcher": "^2.1.0",
     "karma-cli": "^1.0.1",
     "karma-jasmine": "^1.1.0",
     "karma-jasmine-html-reporter": "^0.2.2",

--- a/package.json
+++ b/package.json
@@ -5,13 +5,14 @@
   "scripts": {
     "build": "tsc -p src/",
     "build:watch": "tsc -p src/ -w",
+    "build:aot": "ngc -p src/tsconfig-aot.json",
+    "build:prod": "npm run build:aot && npm run rollup",
     "start": "concurrently \"npm run build:watch\" \"npm run serve\"",
     "serve": "lite-server -c=bs-config.json",
     "postinstall": "bower install",
-    "build:prod": "npm run build:aot && npm run rollup",
     "test": "npm run build && karma start karma.conf.js --single-run",
     "test:watch": "concurrently \"npm run build:watch\" \"karma start karma.conf.js\"",
-    "build:aot": "ngc -p src/tsconfig-aot.json",
+
     "rollup": "rollup -c rollup-config.js"
   },
   "author": "",

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -12,5 +12,8 @@
     "declaration": true,
     "noImplicitAny": false,
     "suppressImplicitAnyIndexErrors": true
-  }
+  },
+  "exclude": [
+    "main.ts"
+  ]
 }


### PR DESCRIPTION
The goal is for the Graph explorer tests to run on every pull request in Travis.

- Fixed Git clone error by changing git url to Https
- Setup Travis to use a headless version of Chrome for testing
- Tests will run on Node v7 and latest stable version
- `npm run test` now runs all tests and terminates the process. `npm run test:watch` is used for local dev and runs tests on file changes