### PR TITLE
Moved post body editor to first tab and fixed ACE bug

### DIFF
--- a/src/app/ace-utils.ts
+++ b/src/app/ace-utils.ts
@@ -1,0 +1,12 @@
+declare let ace:any;
+
+/**
+ * ACE editors don't update their content when a parent DOM element is hidden. After
+ * clicking on tabs (request body/response, response body/response) the ACE editors
+ * should be notified to refresh their views
+ */
+export function refreshAceEditorsContent() {
+    for (let aceEditor of $(".ace_editor").toArray()) {
+        ace.edit(aceEditor).resize();
+    }
+}

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -18,6 +18,7 @@ import { parseMetadata, constructGraphLinksFromFullPath } from "./graph-structur
 import { ResponseStatusBarComponent } from "./response-status-bar.component";
 import { GenericDialogComponent } from "./generic-message-dialog.component";
 import { getString } from "./localization-helpers";
+import { refreshAceEditorsContent } from "./ace-utils";
 
 declare let mwf, ga, moment;
 
@@ -38,10 +39,10 @@ declare let mwf, ga, moment;
 })
 export class AppComponent extends GraphExplorerComponent implements OnInit, AfterViewInit {
     ngAfterViewInit(): void {
-      // Headers aren't updated when that tab is hidden, so when clicking on any tab reinsert the headers
+      // when clicking on a pivot (request headers/body or response headers/body), notify ACE to update content
       if (typeof $ !== "undefined") {
-        $("#response-viewer-labels .ms-Pivot-link").on('click', () => {
-            insertHeadersIntoResponseViewer(AppComponent.lastApiCallHeaders)
+        $("api-explorer .ms-Pivot-link").on('click', () => {
+          setTimeout(refreshAceEditorsContent, 0);
         });
       }
 
@@ -52,7 +53,6 @@ export class AppComponent extends GraphExplorerComponent implements OnInit, Afte
 
   static svc:GraphService;
   static messageBarContent:MessageBarContent;
-  static lastApiCallHeaders: Headers;
   static _changeDetectionRef:ChangeDetectorRef;
   static message:Message;
 
@@ -204,8 +204,6 @@ export class AppComponent extends GraphExplorerComponent implements OnInit, Afte
 
     // common ops for successful and unsuccessful
     AppComponent.explorerValues.requestInProgress = false;
-
-    AppComponent.lastApiCallHeaders = res.headers;
 
     let {status, headers} = res;
     query.duration = (new Date()).getTime() - query.requestSentAt.getTime();

--- a/src/app/request-editors.component.html
+++ b/src/app/request-editors.component.html
@@ -1,12 +1,17 @@
 <div class="ms-Pivot">
     <ul class="ms-Pivot-links">
-        <li class="ms-Pivot-link is-selected" data-content="headers" [attr.title]="getStr('request header')" tabindex="1">
-            {{getStr('request header')}}
-        </li>
-        <li class="ms-Pivot-link" data-content="body" [attr.title]="getStr('request body')" (click)="initPostBodyEditor()" tabindex="1">
+        <li class="ms-Pivot-link is-selected" data-content="body" [attr.title]="getStr('request body')" tabindex="1">
             {{getStr('request body')}}
         </li>
+        <li class="ms-Pivot-link" data-content="headers" [attr.title]="getStr('request header')" tabindex="1">
+            {{getStr('request header')}}
+        </li>
     </ul>
+    <div class="ms-Pivot-content" data-content="body">
+        <div id="requestBodyContainer">
+            <div id="post-body-editor"></div>
+        </div>
+    </div>
     <div class="ms-Pivot-content" data-content="headers">
         <div id="headers-editor">
             <table>
@@ -34,11 +39,6 @@
                     </td>
                 </tr>
             </table>
-        </div>
-    </div>
-    <div class="ms-Pivot-content" data-content="body">
-        <div id="requestBodyContainer">
-            <div id="post-body-editor"></div>
         </div>
     </div>
 </div>

--- a/src/app/request-editors.component.ts
+++ b/src/app/request-editors.component.ts
@@ -16,6 +16,7 @@ declare let mwf;
 export class RequestEditorsComponent extends GraphExplorerComponent implements AfterViewInit {
     ngAfterViewInit(): void {
         this.addEmptyHeader();
+        this.initPostBodyEditor();
     }
 
     initPostBodyEditor() {


### PR DESCRIPTION
- Moved ACE editor for POST body to be the first tab
- ACE editors don't update their content when a parent node is hidden. We had a custom workaround for the response ACE editors and this has been replaced with a generic solution for all ACE editors for the request and response areas.