### PR TITLE
Changed to popup authentication instead of page redirect and configurable Graph API Url

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -84,7 +84,7 @@ export class AppComponent extends GraphExplorerComponent implements OnInit, Afte
       Language: "en-US",
       DefaultUserScopes: "openid profile User.ReadWrite User.ReadBasic.All Sites.ReadWrite.All Contacts.ReadWrite People.Read Notes.ReadWrite.All Tasks.ReadWrite  Mail.ReadWrite Files.ReadWrite.All Calendars.ReadWrite",
       AuthUrl: "https://login.microsoftonline.com",
-      GraphUrl: "https://graph.microsoft.com",
+      GraphUrl: getParameterByName("GraphUrl") || "https://graph.microsoft.com",
       GraphVersions: GraphApiVersions,
       PathToBuildDir: ""
   };

--- a/src/app/auth.ts
+++ b/src/app/auth.ts
@@ -10,8 +10,6 @@ import { GraphService } from "./graph-service";
 import { PermissionScopes } from "./scopes";
 import { getParameterByName } from "./util";
 
-declare const hello: any;
-
 export function initAuth(options:ExplorerOptions, apiService:GraphService, changeDetectorRef: ChangeDetectorRef) {
 	setInterval(refreshAccessToken, 1000 * 60 * 10); // refresh access token every 10 minutes
 	hello.init({
@@ -38,7 +36,7 @@ export function initAuth(options:ExplorerOptions, apiService:GraphService, chang
 			// This means no POST operations in <=IE9
 			form: false
 		}
-	});
+	} as any);
 
 	hello.init({
 			msft: options.ClientId,
@@ -118,7 +116,11 @@ export function refreshAccessToken() {
 		domain_hint: 'organizations'
 	}
 
-	hello('msft').login(loginProperties).then((a) => {
+	// hellojs might have a bug with their types for .login()
+	// https://github.com/MrSwitch/hello.js/issues/514
+
+	const silentLoginRequest: Promise<void> = hello('msft').login(loginProperties) as any;
+	silentLoginRequest.then(() => {
 		console.log("Successfully refreshed access token.", new Date())
 	}, (e) => {
 		console.error("Error refreshing access token", e, new Date());

--- a/src/app/authentication.component.ts
+++ b/src/app/authentication.component.ts
@@ -27,7 +27,7 @@ export class AuthenticationComponent extends GraphExplorerComponent {
   // https://docs.microsoft.com/en-us/azure/active-directory/active-directory-v2-protocols-implicit
   login() {
       let loginProperties = {
-        display: 'page',
+        display: 'popup',
         response_type: "id_token token",
         response_mode: "fragment",
         nonce: 'graph_explorer',

--- a/src/app/share-link-btn.component.ts
+++ b/src/app/share-link-btn.component.ts
@@ -4,6 +4,7 @@
 
 import { Component, AfterViewInit } from '@angular/core';
 import { GraphExplorerComponent } from "./GraphExplorerComponent";
+import { AllowedGraphDomains } from "./base";
 
 declare let fabric:any;
 
@@ -34,23 +35,45 @@ export class ShareLinkBtnComponent extends GraphExplorerComponent implements Aft
         return this.createShareLink(this.explorerValues.endpointUrl, this.explorerValues.selectedOption, this.explorerValues.selectedVersion);
     }
 
-    createShareLink(fullRequestUrl, action, version) {    
-        return window.location.origin + window.location.pathname + "?request=" + this.extractGraphEndpoint(fullRequestUrl) + "&method=" + action + "&version=" + version;
+    createShareLink(fullRequestUrl, action, version) {
+        let callComponents = this.getGraphCallComponents(fullRequestUrl);
+        return window.location.origin
+            + window.location.pathname
+            + "?request=" + callComponents.requestUrl
+             + "&method=" + action
+             + "&version=" + callComponents.version
+             + "&GraphUrl=" + callComponents.graphDeploymentUrl;
     }
 
-    extractGraphEndpoint(fullRequestUrl) {
+
+    /**
+     * Given a URL like https://graph.microsoft.com/v1.0/some/graph/api/call, extract
+     * https://graph.microsoft.com and some/graph/api/call
+     */
+    getGraphCallComponents(fullRequestUrl: string): GraphApiCallUrlComponents  {
         if (!fullRequestUrl) {
             return;
         }
-        let requestUrl = fullRequestUrl.split('.com')
-        requestUrl.shift();
-        
-        if (requestUrl.length === 0) {
-            return;
+
+        for (const graphDeploymentUrl of AllowedGraphDomains) {
+            if (fullRequestUrl.startsWith(graphDeploymentUrl)) {
+
+                let apiCall = fullRequestUrl.split(graphDeploymentUrl)[1];
+                let requestUrlComponents = apiCall.split('/');
+
+
+                return {
+                    graphDeploymentUrl,
+                    version: requestUrlComponents[1],
+                    requestUrl: requestUrlComponents.slice(2, requestUrlComponents.length).join('/')
+                }
+            }
         }
-        var requestUrlComponents = requestUrl[0].split('/');
-        requestUrlComponents.shift(); //remove empty item
-        requestUrlComponents.shift(); //remove version
-        return (requestUrlComponents.join('/'));
     }
+}
+
+interface GraphApiCallUrlComponents {
+    graphDeploymentUrl?: string // https://graph.microsoft.com
+    requestUrl?: string // /me/people
+    version?: string // beta
 }


### PR DESCRIPTION
- Changed hello.js to use popup redirect, which means developers don't lose the app state (what they're working on) when authenticating
- Exposed Graph URL setting to support other graph deployments
  - Support parsing URL for deep linking to api calls that don't start with graph.microsoft.com
  - When creating share links, add the graph deployment URL parameter
- Removed global hello declaration as an `any` type to improve type checking