### PR TITLE
Sample query updates

### DIFF
--- a/sample-queries.csv
+++ b/sample-queries.csv
@@ -145,12 +145,11 @@ Personal Contacts,POST,add contact,/v1.0/me/contacts,Update the Request Body and
 OneDrive,GET,all the items in my drive,/v1.0/me/drive/root/children,,https://developer.microsoft.com/en-us/graph/docs/api-reference/v1.0/api/item_list_children,BOTH,,
 OneDrive,GET,my recent files,/v1.0/me/drive/recent,,https://developer.microsoft.com/en-us/graph/docs/api-reference/v1.0/api/drive_recent,BOTH,,
 OneDrive,GET,files shared with me,/v1.0/me/drive/sharedWithMe,,https://developer.microsoft.com/en-us/graph/docs/api-reference/v1.0/api/drive_sharedwithme,BOTH,,
-OneDrive,GET,all of my excel files,"/v1.0/me/drive/root/search(q='.xlsx')?select=name,id,webUrl",,https://developer.microsoft.com/en-us/graph/docs/api-reference/v1.0/api/item_search,BOTH,,
+OneDrive,GET,search my OneDrive,"/v1.0/me/drive/root/search(q='finance')?select=name,id,webUrl",,https://developer.microsoft.com/en-us/graph/docs/api-reference/v1.0/api/item_search,BOTH,,
 OneDrive,POST,create a folder,/v1.0/me/drive/root/children,Update the Request Body and select Run Query.,https://developer.microsoft.com/en-us/graph/docs/api-reference/v1.0/api/item_post_children,BOTH,"{
   ""name"": ""New Folder"",
   ""folder"": { }
 }",Content-type: application/json
-Excel,GET,all of my excel files,"/v1.0/me/drive/root/search(q='.xlsx')?select=name,id,webUrl",,https://developer.microsoft.com/en-us/graph/docs/api-reference/v1.0/api/item_search,BOTH,,
 Excel,POST,create session,/v1.0/me/drive/items/{drive-item-id}/workbook/createSession,"This query requires a driveItem id.  To find the ID of the driveItem that corresponds to an Excel Workbook, you can run: GET https://graph.microsoft.com/v1.0/me/drive/root/search(q='.xlsx')?select=name,id,webUrl.",https://developer.microsoft.com/en-us/graph/docs/api-reference/v1.0/resources/excel,AAD,"{ ""persistChanges"": true }",Content-type: application/json
 Excel,GET,worksheets in a workbook,/v1.0/me/drive/items/{drive-item-id}/workbook/worksheets,"This query requires a driveItem id.  To find the ID of the driveItem that corresponds to an Excel Workbook, you can run: GET https://graph.microsoft.com/v1.0/me/drive/root/search(q='.xlsx')?select=name,id,webUrl.",https://developer.microsoft.com/en-us/graph/docs/api-reference/v1.0/api/workbook_list_worksheets,AAD,,
 Excel,POST,add a new worksheet,/v1.0/me/drive/items/{drive-item-id}/workbook/worksheets/,"This query requires a driveItem id.  To find the ID of the driveItem that corresponds to an Excel Workbook, you can run: GET https://graph.microsoft.com/v1.0/me/drive/root/search(q='.xlsx')?select=name,id,webUrl.",https://developer.microsoft.com/en-us/graph/docs/api-reference/v1.0/api/worksheetcollection_add,AAD,"{

--- a/sample-queries.csv
+++ b/sample-queries.csv
@@ -125,7 +125,7 @@ Outlook Calendar,POST,schedule a meeting,/v1.0/me/events,Update the Request Body
         ""end"": {
             ""dateTime"": ""{next-week}"",
             ""timeZone"": ""UTC""
-        },
+        }
     }",Content-type: application/json
 Outlook Calendar,GET,track changes on my events for the next week,/v1.0/me/calendarView/delta?startDateTime={today}&endDateTime={next-week},"This query uses date and time parameters. Use an ISO 8601 format. For example, ""2017-04-30T19:00:00.0000000"".",https://developer.microsoft.com/en-us/graph/docs/concepts/delta_query_events,BOTH,,
 Personal Contacts,GET,my contacts,/v1.0/me/contacts,,https://developer.microsoft.com/en-us/graph/docs/api-reference/v1.0/api/user_list_contacts,BOTH,,

--- a/src/app/gen-queries.ts
+++ b/src/app/gen-queries.ts
@@ -350,8 +350,8 @@ export const SampleQueries: SampleQuery[] = [
 {
     "category": "OneDrive",
     "method": "GET",
-    "humanName": "all of my excel files",
-    "requestUrl": "/v1.0/me/drive/root/search(q='.xlsx')?select=name,id,webUrl",
+    "humanName": "search my OneDrive",
+    "requestUrl": "/v1.0/me/drive/root/search(q='finance')?select=name,id,webUrl",
     "docLink": "https://developer.microsoft.com/en-us/graph/docs/api-reference/v1.0/api/item_search"
 },
 {
@@ -368,13 +368,6 @@ export const SampleQueries: SampleQuery[] = [
     ],
     "postBody": "{\n  \"name\": \"New Folder\",\n  \"folder\": { }\n}",
     "tip": "Update the Request Body and select Run Query."
-},
-{
-    "category": "Excel",
-    "method": "GET",
-    "humanName": "all of my excel files",
-    "requestUrl": "/v1.0/me/drive/root/search(q='.xlsx')?select=name,id,webUrl",
-    "docLink": "https://developer.microsoft.com/en-us/graph/docs/api-reference/v1.0/api/item_search"
 },
 {
     "category": "Excel",

--- a/src/app/gen-queries.ts
+++ b/src/app/gen-queries.ts
@@ -293,7 +293,7 @@ export const SampleQueries: SampleQuery[] = [
             "value": "application/json"
         }
     ],
-    "postBody": "{\n        \"subject\": \"My event\",\n        \"start\": {\n            \"dateTime\": \"{today}\",\n            \"timeZone\": \"UTC\"\n        },\n        \"end\": {\n            \"dateTime\": \"{next-week}\",\n            \"timeZone\": \"UTC\"\n        },\n    }",
+    "postBody": "{\n        \"subject\": \"My event\",\n        \"start\": {\n            \"dateTime\": \"{today}\",\n            \"timeZone\": \"UTC\"\n        },\n        \"end\": {\n            \"dateTime\": \"{next-week}\",\n            \"timeZone\": \"UTC\"\n        }\n    }",
     "tip": "Update the Request Body and select Run Query."
 },
 {

--- a/translation_files/en-US.json
+++ b/translation_files/en-US.json
@@ -180,5 +180,6 @@
   "update an open extension": "update an open extension",
   "user by email": "user by email",
 
-  "explorer-error": "We had an issue sending this request to the Graph API.  For assistance, connect with us on StackOverflow with the tag [microsoftgraph]."
+  "explorer-error": "We had an issue sending this request to the Graph API.  For assistance, connect with us on StackOverflow with the tag [microsoftgraph].",
+  "search my OneDrive": "search my OneDrive"
 }


### PR DESCRIPTION
- Fixed indentation issue on `schedule a meeting` due to trailing comma in post body
- Replaced GET `all of my excel files` with GET `search my OneDrive` (started in PR #61 ) and added `search my OneDrive` string to `en-us.json` to expose it for localization
- Removed GET `all of my excel files` in the `OneDrive` sample category
