### PR TITLE
Removed the id_token. We aren't using it.

### DIFF
--- a/src/app/auth.ts
+++ b/src/app/auth.ts
@@ -107,7 +107,7 @@ export function refreshAccessToken() {
 
 	let loginProperties = {
 		display: 'none',
-		response_type: "id_token token",
+		response_type: "token",
 		response_mode: "fragment",
 		nonce: 'graph_explorer',
 		prompt: 'none',

--- a/src/app/authentication.component.ts
+++ b/src/app/authentication.component.ts
@@ -28,7 +28,7 @@ export class AuthenticationComponent extends GraphExplorerComponent {
   login() {
       let loginProperties = {
         display: 'page',
-        response_type: "id_token token",
+        response_type: "token",
         response_mode: "fragment",
         nonce: 'graph_explorer',
         prompt: 'select_account',

--- a/src/app/scopes-dialog.component.ts
+++ b/src/app/scopes-dialog.component.ts
@@ -48,7 +48,7 @@ export class ScopesDialogComponent extends GraphExplorerComponent implements Aft
       // @todo type HelloJSLoginOptions
       let loginProperties = {
         display: 'page',
-        response_type: "id_token token",
+        response_type: "token",
         nonce: 'graph_explorer',
         prompt: 'select_account',
         // login_hint: AppComponent.explorerValues.authentication.user.emailAddress, // breaks MSA login


### PR DESCRIPTION
Per email with Maxim, the id_token is redundant. Plus, we aren't using it. This will greatly reduce the size of our redirect URL