### PR TITLE
Add Bookings scopes

### DIFF
--- a/src/app/scopes.ts
+++ b/src/app/scopes.ts
@@ -503,5 +503,37 @@ export const PermissionScopes: PermissionScope[] = [
     longDescription: "Manage the state and settings of all Microsoft education apps on behalf of the user.",
     preview: true,
     admin: true
+  },
+  {
+    name: "Bookings.Read.All",
+    description: "Read bookings information",
+    longDescription:
+      "Allows the app to read bookings appointments, businesses, customers, services, and staff on your behalf.",
+    preview: true,
+    admin: false
+  },
+  {
+    name: "BookingsAppointment.ReadWrite.All",
+    description: "Read and write booking appointments",
+    longDescription:
+      "Allows the app to read and write bookings appointments and customers, and additionally allows read businesses information, services, and staff on your behalf.",
+    preview: true,
+    admin: false
+  },
+  {
+    name: "Bookings.ReadWrite.All",
+    description: "Read and write bookings information",
+    longDescription:
+      "Allows the app to read and write Bookings appointments, businesses, customers, services, and staff on your behalf. Does not allow create, delete and publish of booking businesses.",
+    preview: true,
+    admin: false
+  },
+  {
+    name: "Bookings.Manage.All",
+    description: "Manage bookings information",
+    longDescription:
+      "Allows the app to read, write and manage bookings appointments, businesses, customers, services, and staff on your behalf.",
+    preview: true,
+    admin: false
   }
 ]


### PR DESCRIPTION
This change adds the scopes needed to invoke the Bookings API using Graph Explorer.

I've tested them by running Graph Explorer locally with these scopes and checking that requests were not accepted by the service without them, but accepted with them.