### PR TITLE
Enable screen readers to read request/response tabs

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -8,7 +8,7 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 
 import { AppComponent } from './app.component';
-import { AriaSelectedDirective } from './aria-selected.directive';
+import { AriaSelectedMSPivotLinkDirective } from './aria-selected.directive';
 import { MainColumnComponent } from './main-column.component'
 import { AuthenticationComponent } from './authentication.component'
 import { FormsModule, ReactiveFormsModule } from '@angular/forms'
@@ -27,7 +27,7 @@ import { GenericDialogComponent } from "./generic-message-dialog.component";
 
 @NgModule({
   imports: [BrowserModule, FormsModule, ReactiveFormsModule, HttpModule, BrowserAnimationsModule],
-  declarations: [AppComponent, AriaSelectedDirective, ResponseStatusBarComponent, AuthenticationComponent, SidebarComponent, QueryRowComponent, MainColumnComponent, HistoryRowComponent, HistoryPanelComponent, MethodBadgeComponent, SampleCategoriesPanelComponent, RequestEditorsComponent, ShareLinkBtnComponent, ScopesDialogComponent, GenericDialogComponent],
+  declarations: [AppComponent, AriaSelectedMSPivotLinkDirective, ResponseStatusBarComponent, AuthenticationComponent, SidebarComponent, QueryRowComponent, MainColumnComponent, HistoryRowComponent, HistoryPanelComponent, MethodBadgeComponent, SampleCategoriesPanelComponent, RequestEditorsComponent, ShareLinkBtnComponent, ScopesDialogComponent, GenericDialogComponent],
   bootstrap: [AppComponent]
 })
 export class AppModule { }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -7,10 +7,11 @@ import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 
-import { AppComponent }  from './app.component';
+import { AppComponent } from './app.component';
+import { AriaSelectedDirective } from './aria-selected.directive';
 import { MainColumnComponent } from './main-column.component'
 import { AuthenticationComponent } from './authentication.component'
-import { FormsModule, ReactiveFormsModule  } from '@angular/forms'
+import { FormsModule, ReactiveFormsModule } from '@angular/forms'
 import { SidebarComponent } from "./sidebar.component";
 import { QueryRowComponent } from "./queryrow.component";
 import { HttpModule } from '@angular/http';
@@ -25,8 +26,8 @@ import { ScopesDialogComponent } from "./scopes-dialog.component";
 import { GenericDialogComponent } from "./generic-message-dialog.component";
 
 @NgModule({
-  imports:      [ BrowserModule, FormsModule, ReactiveFormsModule, HttpModule, BrowserAnimationsModule ],
-  declarations: [ AppComponent, ResponseStatusBarComponent, AuthenticationComponent, SidebarComponent, QueryRowComponent, MainColumnComponent, HistoryRowComponent, HistoryPanelComponent, MethodBadgeComponent, SampleCategoriesPanelComponent, RequestEditorsComponent, ShareLinkBtnComponent, ScopesDialogComponent, GenericDialogComponent ],
-  bootstrap:    [ AppComponent ]
+  imports: [BrowserModule, FormsModule, ReactiveFormsModule, HttpModule, BrowserAnimationsModule],
+  declarations: [AppComponent, AriaSelectedDirective, ResponseStatusBarComponent, AuthenticationComponent, SidebarComponent, QueryRowComponent, MainColumnComponent, HistoryRowComponent, HistoryPanelComponent, MethodBadgeComponent, SampleCategoriesPanelComponent, RequestEditorsComponent, ShareLinkBtnComponent, ScopesDialogComponent, GenericDialogComponent],
+  bootstrap: [AppComponent]
 })
 export class AppModule { }

--- a/src/app/aria-selected.directive.ts
+++ b/src/app/aria-selected.directive.ts
@@ -1,19 +1,21 @@
-// AriaSelectedDirective - An attribute directive that uses the 'ariaselected' selector to 
-// to apply the aria-selected attribute and value when the item gains and loses focus. 
+// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+// AriaSelectedMSPivotLinkDirective - An attribute directive that uses the ms-Pivot-link class selector to 
+// to apply the aria-selected attribute and value when the tab gains and loses focus.
+// https://dev.office.com/fabric-js/Components/Pivot/Pivot.html
 import { Directive, ElementRef, Renderer2, HostListener } from '@angular/core';
 @Directive({
-    selector: '[ariaselected]'
-    // TODO: Investigate whether we target ms-pivot-link class with this selector. I think we can
-    // since this class is used for tabs. 
+    selector: '.ms-Pivot-link'
 })
-export class AriaSelectedDirective {
+export class AriaSelectedMSPivotLinkDirective {
     constructor(private el: ElementRef, private renderer: Renderer2) {
         this.el = el;
         this.renderer = renderer;
     }
 
-    // TODO: Make sure this works from the keyboard.
-    // Set the aria-selected attribute to true when the tab (ms-pivot-link) is selected.
+    // Set the aria-selected attribute to true when the tab (ms-pivot-link) gains focus.
     @HostListener('focus')
     onFocus() {
         this.renderer.setAttribute(this.el.nativeElement, 'aria-selected', 'true');

--- a/src/app/aria-selected.directive.ts
+++ b/src/app/aria-selected.directive.ts
@@ -1,0 +1,27 @@
+// AriaSelectedDirective - An attribute directive that uses the 'ariaselected' selector to 
+// to apply the aria-selected attribute and value when the item gains and loses focus. 
+import { Directive, ElementRef, Renderer2, HostListener } from '@angular/core';
+@Directive({
+    selector: '[ariaselected]'
+    // TODO: Investigate whether we target ms-pivot-link class with this selector. I think we can
+    // since this class is used for tabs. 
+})
+export class AriaSelectedDirective {
+    constructor(private el: ElementRef, private renderer: Renderer2) {
+        this.el = el;
+        this.renderer = renderer;
+    }
+
+    // TODO: Make sure this works from the keyboard.
+    // Set the aria-selected attribute to true when the tab (ms-pivot-link) is selected.
+    @HostListener('focus')
+    onFocus() {
+        this.renderer.setAttribute(this.el.nativeElement, 'aria-selected', 'true');
+    }
+
+    // Set the aria-selected attribute to false when the tab (ms-pivot-link) loses focus.
+    @HostListener('blur')
+    onBlur() {
+        this.renderer.setAttribute(this.el.nativeElement, 'aria-selected', 'false');
+    }
+}

--- a/src/app/main-column.component.html
+++ b/src/app/main-column.component.html
@@ -1,6 +1,7 @@
 <div id="request-bar-row-form" layout="row" layout-align="start center">
     <!-- HTTP METHOD -->
-    <div [title]="isAuthenticated() ? '' : getStr('login to send requests')" #httpMethod id="httpMethodSelect" [ngClass]="explorerValues.selectedOption" class="c-select f-border first-row-mobile bump-flex-row-mobile fixed-with-mwf-menu">
+    <div [title]="isAuthenticated() ? '' : getStr('login to send requests')" #httpMethod id="httpMethodSelect" [ngClass]="explorerValues.selectedOption"
+        class="c-select f-border first-row-mobile bump-flex-row-mobile fixed-with-mwf-menu">
         <select [disabled]="!isAuthenticated()">
             <option *ngFor="let choice of methods">{{choice}}</option>
         </select>
@@ -16,7 +17,9 @@
     </div>
 
     <div id="graph-request-url" class="c-search" autocomplete="off" name="form1">
-        <input [(ngModel)]="explorerValues.endpointUrl" (keydown)="endpointInputKeyDown($event)" role="combobox" aria-controls="auto-suggest-default-2" aria-autocomplete="both" aria-expanded="false" type="search" name="search-field" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false">
+        <input [(ngModel)]="explorerValues.endpointUrl" (keydown)="endpointInputKeyDown($event)" role="combobox" aria-controls="auto-suggest-default-2"
+            aria-autocomplete="both" aria-expanded="false" type="search" name="search-field" autocomplete="off" autocorrect="off"
+            autocapitalize="off" spellcheck="false">
 
         <div class="m-auto-suggest" #autoSuggest id="auto-suggest-default-2" role="group">
             <ul class="c-menu f-auto-suggest-scroll" aria-hidden="true" data-js-auto-suggest-position="default" tabindex="0" role="listbox"></ul>
@@ -27,7 +30,8 @@
     </div>
 
     <button name="button" class="c-button explorer-form-row bump-flex-row-mobile" type="submit" id="submitBtn" (click)="submit()">
-        <span [hidden]="explorerValues.requestInProgress"><i id="go-lightning-icon" class="ms-Icon ms-Icon--LightningBolt" style="padding-right: 10px;" aria-hidden="true"></i>{{getStr('Run Query')}}</span>
+        <span [hidden]="explorerValues.requestInProgress">
+            <i id="go-lightning-icon" class="ms-Icon ms-Icon--LightningBolt" style="padding-right: 10px;" aria-hidden="true"></i>{{getStr('Run Query')}}</span>
         <div class="ms-Spinner" [hidden]="!explorerValues.requestInProgress"></div>
     </button>
 </div>
@@ -39,10 +43,10 @@
 <share-link-btn></share-link-btn>
 <div class="ms-Pivot" id="response-viewer-labels" tabindex="-1">
     <ul class="ms-Pivot-links">
-        <li class="ms-Pivot-link is-selected" data-content="response" tabindex="1">
+        <li class="ms-Pivot-link is-selected" data-content="response" [attr.title]="getStr('Response Preview')" tabindex="1" role="tab">
             {{getStr('Response Preview')}}
         </li>
-        <li class="ms-Pivot-link" data-content="response-headers" tabindex="1">
+        <li class="ms-Pivot-link" data-content="response-headers" [attr.title]="getStr('Response Headersnav')" tabindex="1" role="tab">
             {{getStr('Response Headers')}}
         </li>
     </ul>

--- a/src/app/request-editors.component.html
+++ b/src/app/request-editors.component.html
@@ -1,10 +1,10 @@
 <div class="ms-Pivot">
     <ul class="ms-Pivot-links">
-        <li ariaselected class="ms-Pivot-link is-selected" aria-selected="true" data-content="body" [attr.title]="getStr('request body')"
-            tabindex="1" role="tab">
+        <li class="ms-Pivot-link is-selected" aria-selected="true" data-content="body" [attr.title]="getStr('request body')" tabindex="1"
+            role="tab">
             {{getStr('request body')}}
         </li>
-        <li ariaselected class="ms-Pivot-link" data-content="headers" [attr.title]="getStr('request header')" tabindex="1" role="tab">
+        <li class="ms-Pivot-link" data-content="headers" [attr.title]="getStr('request header')" tabindex="1" role="tab">
             {{getStr('request header')}}
         </li>
     </ul>

--- a/src/app/request-editors.component.html
+++ b/src/app/request-editors.component.html
@@ -1,9 +1,9 @@
 <div class="ms-Pivot">
     <ul class="ms-Pivot-links">
-        <li class="ms-Pivot-link is-selected" data-content="body" [attr.title]="getStr('request body')" tabindex="1">
+        <li class="ms-Pivot-link is-selected" data-content="body" [attr.title]="getStr('request body')" tabindex="1" role="tab">
             {{getStr('request body')}}
         </li>
-        <li class="ms-Pivot-link" data-content="headers" [attr.title]="getStr('request header')" tabindex="1">
+        <li class="ms-Pivot-link" data-content="headers" [attr.title]="getStr('request header')" tabindex="1" role="tab">
             {{getStr('request header')}}
         </li>
     </ul>
@@ -21,7 +21,8 @@
                 </tr>
                 <tr *ngFor="let header of explorerValues.headers; let idx = index" class="header-row">
                     <td class="half-width-col">
-                        <input id="default" class="c-text-field" (ngModelChange)="createNewHeaderField()" [(ngModel)]="header.name" [disabled]="header.readonly" type="text" [attr.placeholder]="getPlaceholder(header)">
+                        <input id="default" class="c-text-field" (ngModelChange)="createNewHeaderField()" [(ngModel)]="header.name" [disabled]="header.readonly"
+                            type="text" [attr.placeholder]="getPlaceholder(header)">
                         <!--<div class="c-search header-autocomplete" autocomplete="off">
                             <input role="combobox" class="c-text-field header-name" (ngModelChange)="createNewHeaderField()" [attr.aria-controls]="'headers-autosuggest-'+idx" aria-autocomplete="both" aria-expanded="false" type="text" [attr.placeholder]="getPlaceholder(header)" [(ngModel)]="header.name" [disabled]="header.readonly">
                             <div class="m-auto-suggest" [attr.id]="'headers-autosuggest-'+idx" role="group">
@@ -32,7 +33,8 @@
 
                     </td>
                     <td class="half-width-col">
-                        <input id="default" class="c-text-field header-value" [(ngModel)]="header.value" [disabled]="header.readonly" type="text" name="default" [class.invisible]="isLastHeader(header)">
+                        <input id="default" class="c-text-field header-value" [(ngModel)]="header.value" [disabled]="header.readonly" type="text"
+                            name="default" [class.invisible]="isLastHeader(header)">
                     </td>
                     <td class="remove-header-btn" [class.invisible]="isLastHeader(header)" (click)="removeHeader(header)">
                         <i class="ms-Icon ms-Icon--Cancel"></i>

--- a/src/app/request-editors.component.html
+++ b/src/app/request-editors.component.html
@@ -1,11 +1,10 @@
 <div class="ms-Pivot">
     <ul class="ms-Pivot-links">
-        <li class="ms-Pivot-link is-selected" aria-selected="true" data-content="body" [attr.title]="getStr('request body')" tabindex="1"
-            role="tab">
+        <li ariaselected class="ms-Pivot-link is-selected" aria-selected="true" data-content="body" [attr.title]="getStr('request body')"
+            tabindex="1" role="tab">
             {{getStr('request body')}}
         </li>
-        <li class="ms-Pivot-link" aria-selected="false" data-content="headers" [attr.title]="getStr('request header')" tabindex="1"
-            role="tab">
+        <li ariaselected class="ms-Pivot-link" data-content="headers" [attr.title]="getStr('request header')" tabindex="1" role="tab">
             {{getStr('request header')}}
         </li>
     </ul>

--- a/src/app/request-editors.component.html
+++ b/src/app/request-editors.component.html
@@ -1,9 +1,11 @@
 <div class="ms-Pivot">
     <ul class="ms-Pivot-links">
-        <li class="ms-Pivot-link is-selected" data-content="body" [attr.title]="getStr('request body')" tabindex="1" role="tab">
+        <li class="ms-Pivot-link is-selected" aria-selected="true" data-content="body" [attr.title]="getStr('request body')" tabindex="1"
+            role="tab">
             {{getStr('request body')}}
         </li>
-        <li class="ms-Pivot-link" data-content="headers" [attr.title]="getStr('request header')" tabindex="1" role="tab">
+        <li class="ms-Pivot-link" aria-selected="false" data-content="headers" [attr.title]="getStr('request header')" tabindex="1"
+            role="tab">
             {{getStr('request header')}}
         </li>
     </ul>


### PR DESCRIPTION
Aria 2103309 request body role

Work:
- [x] Add missing tab titles.
- [x] Add role attribute so that screen reader call these elements out as being tabs.
- [x] Add event listeners for onFocus and onBlur to add and set the aria-selected attribute.