### PR TITLE
Added button names, fixed sample category title accessibility

### DIFF
--- a/src/app/query-runner.service.ts
+++ b/src/app/query-runner.service.ts
@@ -183,7 +183,7 @@ export class QueryRunnerService {
       text += getString(AppComponent.Options, "Failure");
     }
 
-    text += ` - ${getString(AppComponent.Options, "Status Code")} ${query.statusCode}`
+    text += ` - ${getString(AppComponent.Options, "Status Code")} ${query.statusCode}, `
 
 
     text += `<span style="font-weight: 800; margin-left: 40px;">${query.duration}ms</span>`;

--- a/src/app/queryrow.component.css
+++ b/src/app/queryrow.component.css
@@ -1,6 +1,6 @@
 .api-query:hover, .c-drawer>button:hover, .api-query:focus, .c-drawer>button:focus, .query-link:focus {
         background: rgba(0,0,0,0.25);
-        outline: 2px solid blue;
+        outline: 2px solid white;
     }
 
     .query-link {

--- a/src/app/queryrow.component.css
+++ b/src/app/queryrow.component.css
@@ -1,6 +1,6 @@
 .api-query:hover, .c-drawer>button:hover, .api-query:focus, .c-drawer>button:focus, .query-link:focus {
         background: rgba(0,0,0,0.25);
-        outline: none;
+        outline: 2px solid blue;
     }
 
     .query-link {

--- a/src/app/response-status-bar.component.html
+++ b/src/app/response-status-bar.component.html
@@ -15,7 +15,7 @@
                 <td>
                     <div class="ms-MessageBar-actionsOneline">
                         <div id="dismiss-btn" class="ms-MessageBar-icon">
-                            <div tabindex="0" role="button" aria-label="Clear message" (click)="clearMessage()">
+                            <div tabindex="0" role="button" aria-label="Close status message" (click)="clearMessage()">
                                 <i class="ms-Icon ms-Icon--Cancel"></i>
                             </div>
                         </div>

--- a/src/app/response-status-bar.component.html
+++ b/src/app/response-status-bar.component.html
@@ -7,15 +7,17 @@
                         <i class="ms-Icon" [ngClass]="message?.icon"></i>
                     </div>
                 </td>
-                    <div class="ms-MessageBar-actionables">
-                        <div class="ms-MessageBar-text" [innerHtml]="messageHTML"></div>
-                    </div>
+                <div class="ms-MessageBar-actionables">
+                    <div class="ms-MessageBar-text" tabindex="0" [innerHtml]="messageHTML"></div>
+                </div>
                 <td>
                 </td>
                 <td>
                     <div class="ms-MessageBar-actionsOneline">
                         <div id="dismiss-btn" class="ms-MessageBar-icon">
-                            <a href="#" (click)="clearMessage()"><i class="ms-Icon ms-Icon--Cancel"></i></a>
+                            <div tabindex="0" role="button" aria-label="Clear message" (click)="clearMessage()">
+                                <i class="ms-Icon ms-Icon--Cancel"></i>
+                            </div>
                         </div>
                     </div>
                 </td>

--- a/src/app/sample-categories-panel.component.css
+++ b/src/app/sample-categories-panel.component.css
@@ -23,7 +23,7 @@ div.c-toggle button {
 }
 
 div.c-toggle button:focus {
-    outline: none;
+    outline: 2px solid blue;
 }
 
 /* core.css frontdoor conflict */

--- a/src/app/sample-categories-panel.component.html
+++ b/src/app/sample-categories-panel.component.html
@@ -1,5 +1,5 @@
 <div id="sample-categories-panel" class="ms-Panel ms-Panel--lg">
-    <button class="ms-Panel-closeButton ms-PanelAction-close" tabindex="0">
+    <button class="ms-Panel-closeButton ms-PanelAction-close" aria-label="Close sample categories" tabindex="0">
         <i class="ms-Panel-closeIcon ms-Icon ms-Icon--Cancel"></i>
     </button>
     <div class="ms-Panel-contentInner">

--- a/src/app/sample-categories-panel.component.html
+++ b/src/app/sample-categories-panel.component.html
@@ -5,11 +5,11 @@
     <div class="ms-Panel-contentInner">
         <p class="ms-Panel-headerText">{{getStr('Sample Categories')}}</p>
         <div class="ms-Panel-content">
-            <div *ngFor="let category of categories" class="category-row">
+            <div *ngFor="let category of categories" class="category-row" [attr.aria-label]="getStr(category.title)" [attr.id]="getId(category.title)">
                 {{getStr(category.title)}} ({{category.queries.length}})
                 <div class="category-switch">
                     <div class="c-toggle" (click)="toggleCategory(category)">
-                        <button id="example-1" name="example-1" role="checkbox" [attr.aria-checked]="category.enabled" aria-labelledby="c-label c-state-label-1"></button>
+                        <button id="example-1" name="example-1" role="checkbox" [attr.aria-checked]="category.enabled" [attr.aria-labelledby]="getId(category.title)"></button>
                         <span [attr.data-on-string]="getStr('On')" [attr.data-off-string]="getStr('Off')" id="c-state-label-1">{{getStr('On')}}</span>
                     </div>
                 </div>

--- a/src/app/sample-categories-panel.component.ts
+++ b/src/app/sample-categories-panel.component.ts
@@ -7,12 +7,12 @@ import { GraphExplorerComponent } from "./GraphExplorerComponent";
 import { SampleQueryCategory } from "./base";
 import { SampleCategories, saveCategoryDisplayState } from "./getting-started-queries";
 
-declare let mwf:any;
+declare let mwf: any;
 
 @Component({
-  selector: 'sample-categories-panel',
-  styleUrls: ['./sample-categories-panel.component.css'],
-  templateUrl: './sample-categories-panel.component.html',
+    selector: 'sample-categories-panel',
+    styleUrls: ['./sample-categories-panel.component.css'],
+    templateUrl: './sample-categories-panel.component.html',
 })
 export class SampleCategoriesPanelComponent extends GraphExplorerComponent implements AfterViewInit {
 
@@ -22,10 +22,17 @@ export class SampleCategoriesPanelComponent extends GraphExplorerComponent imple
         }])
     }
 
-    toggleCategory(category:SampleQueryCategory) {
+    toggleCategory(category: SampleQueryCategory) {
         category.enabled = !category.enabled;
         saveCategoryDisplayState(category);
     }
 
-    categories:SampleQueryCategory[] = SampleCategories;
+    categories: SampleQueryCategory[] = SampleCategories;
+
+    // Creates an identifier from the category title by removing whitespace. We need this to 
+    // have the checkbox elements labelled by the containing category row so that screen readers 
+    // correctly state the purpose of the checkbox.
+    getId(title: string): string {
+        return this.getStr(title).replace(/\s+/, "");
+    }
 }


### PR DESCRIPTION
- [x] fd9b The message bar close button now has a name that is read by screen readers.
- [x] cf6a The message bar status is now being read by screen readers.
- [x] cafb The close button in the Sample Categories selection panel now has a name and is read by screen readers. 
- [x] 4802 Sample category titles are now readable by screen readers when tabbing through the results.
- [x] 1834 Sample category selection is now apparent when tabbing through the check boxes. 