### PR TITLE
Added outlining to request/response tab items for onFocus and onHover

### DIFF
--- a/src/app/main-column.component.css
+++ b/src/app/main-column.component.css
@@ -79,3 +79,8 @@ button.c-button[type=submit]:focus:not(.x-hidden-focus) {
 :host /deep/ button {
     line-height: 1;
 }
+
+.ms-Pivot-link:hover, .ms-Pivot-link:focus {
+    background: rgba(0,0,0,0.25);
+    outline: 2px solid white;
+}

--- a/src/app/request-editors.component.css
+++ b/src/app/request-editors.component.css
@@ -49,3 +49,8 @@ td.remove-header-btn i {
 .ms-Pivot-content {
     margin-top: 10px;
 }
+
+.ms-Pivot-link:hover, .ms-Pivot-link:focus {
+    background: rgba(0,0,0,0.25);
+    outline: 2px solid white;
+}


### PR DESCRIPTION
Provides outlining to request/response body/headers tabs. Also addresses this in high contrast mode. This is the same outlining applied to the sample query rows.

![image](https://user-images.githubusercontent.com/8527305/36571322-05f96798-17eb-11e8-9b1d-55ba1c36bdf8.png)


![image](https://user-images.githubusercontent.com/8527305/36571307-ede76574-17ea-11e8-9e94-f06a59f9e172.png)
