### PR TITLE
Aria 450730 scopes dialog needs love

### DIFF
--- a/src/app/scopes-dialog.component.css
+++ b/src/app/scopes-dialog.component.css
@@ -40,10 +40,15 @@
 }
 
 label.c-label {
-    margin-top: 0px;
-    margin-bottom: 20px;
+    margin-top: 10px;
+    margin-bottom: 10px;
 }
 
 .preview-label {
     margin-left: 10px;
+}
+
+.scopeRow:hover, .scopeRow:focus {
+    background: rgba(0,0,0,0.25);
+    outline: 2px solid white;
 }

--- a/src/app/scopes-dialog.component.html
+++ b/src/app/scopes-dialog.component.html
@@ -6,7 +6,8 @@
     <p class="ms-Dialog-subText">Select different
         <a class="ms-Link" href="https://developer.microsoft.com/graph/docs/concepts/permissions_reference" target="_blank">permissions</a> to try out Microsoft Graph API endpoints.</p>
     <div class="ms-Dialog-content">
-        <div id="scopes-list-table-container">
+
+        <div id="scopes-list-table-container" #scopesListTableContainer [style.height.px]="getScopesListTableHeight()">
             <table class="ms-Table" id="scopes-list-table">
                 <tr *ngFor="let scope of scopes">
                     <td class="scopeRow">
@@ -34,7 +35,7 @@
                     <div class="ms-MessageBar-icon">
                         <i class="ms-Icon ms-Icon--Info"></i>
                     </div>
-                    <div class="ms-MessageBar-text">
+                    <div class="ms-MessageBar-text" role="alert" aria-live="assertive">
                         {{getStr('To change permissions, you will need to log-in again.')}}
                         <br />
                     </div>
@@ -47,7 +48,7 @@
                     <div class="ms-MessageBar-icon">
                         <i class="ms-Icon ms-Icon--Info"></i>
                     </div>
-                    <div class="ms-MessageBar-text">
+                    <div class="ms-MessageBar-text" role="alert" aria-live="assertive">
                         You have selected permissions that only an administrator can grant. To get access, an administrator can grant
                         <a class="ms-Link" href="#" [style.font-size.px]="15" (click)="startAdminConsentFlow()">access to your entire organization</a>.
                         <br />

--- a/src/app/scopes-dialog.component.html
+++ b/src/app/scopes-dialog.component.html
@@ -3,7 +3,8 @@
         <i class="ms-Icon ms-Icon--Cancel"></i>
     </button>
     <div class="ms-Dialog-title">{{getStr('modify permissions')}}</div>
-    <p class="ms-Dialog-subText">Select different <a class="ms-Link" href="https://developer.microsoft.com/graph/docs/concepts/permissions_reference" target="_blank">permissions</a> to try out Microsoft Graph API endpoints.</p>
+    <p class="ms-Dialog-subText">Select different
+        <a class="ms-Link" href="https://developer.microsoft.com/graph/docs/concepts/permissions_reference" target="_blank">permissions</a> to try out Microsoft Graph API endpoints.</p>
     <div class="ms-Dialog-content">
         <div id="scopes-list-table-container">
             <table class="ms-Table" id="scopes-list-table">
@@ -11,8 +12,11 @@
                     <td>
                         <div class="c-checkbox">
                             <label class="c-label">
-                                <input type="checkbox" [disabled]="scope.name == 'openid'" (change)="toggleScopeEnabled(scope)" name="checkboxId1" value="value1" [checked]="scope.enabledTarget">
-                                <span aria-hidden="true">{{scope.name}}<i class="preview-label" *ngIf="scope.preview">{{getStr('Preview')}}</i></span>
+                                <input type="checkbox" [disabled]="scope.name == 'openid'" (change)="toggleScopeEnabled(scope)" name="checkboxId1" value="value1"
+                                    [checked]="scope.enabledTarget" [attr.aria-label]="getScopeLabel(scope.name)">
+                                <span aria-hidden="true">{{scope.name}}
+                                    <i class="preview-label" *ngIf="scope.preview">{{getStr('Preview')}}</i>
+                                </span>
                             </label>
                         </div>
                     </td>
@@ -27,13 +31,13 @@
         <div *ngIf="scopeListIsDirty()">
             <div class="ms-MessageBar ms-MessageBar--warning">
                 <div class="ms-MessageBar-content">
-                <div class="ms-MessageBar-icon">
-                    <i class="ms-Icon ms-Icon--Info"></i>
-                </div>
-                <div class="ms-MessageBar-text">
-                    {{getStr('To change permissions, you will need to log-in again.')}}
-                    <br />
-                </div>
+                    <div class="ms-MessageBar-icon">
+                        <i class="ms-Icon ms-Icon--Info"></i>
+                    </div>
+                    <div class="ms-MessageBar-text">
+                        {{getStr('To change permissions, you will need to log-in again.')}}
+                        <br />
+                    </div>
                 </div>
             </div>
         </div>
@@ -44,7 +48,8 @@
                         <i class="ms-Icon ms-Icon--Info"></i>
                     </div>
                     <div class="ms-MessageBar-text">
-                        You have selected permissions that only an administrator can grant.  To get access, an administrator can grant <a class="ms-Link" href="#" [style.font-size.px]="15" (click)="startAdminConsentFlow()">access to your entire organization</a>.
+                        You have selected permissions that only an administrator can grant. To get access, an administrator can grant
+                        <a class="ms-Link" href="#" [style.font-size.px]="15" (click)="startAdminConsentFlow()">access to your entire organization</a>.
                         <br />
                     </div>
                 </div>
@@ -53,10 +58,10 @@
     </div>
     <div class="ms-Dialog-actions">
         <button class="ms-Button ms-Dialog-action ms-Button--primary" [disabled]="!scopeListIsDirty()" (click)="getNewAccessToken()">
-            <span class="ms-Button-label" style="text-transform: capitalize;">{{getStr('modify permissions')}}</span> 
+            <span class="ms-Button-label" style="text-transform: capitalize;">{{getStr('modify permissions')}}</span>
         </button>
         <button class="ms-Button ms-Dialog-action">
-            <span class="ms-Button-label">{{getStr('Close')}}</span> 
+            <span class="ms-Button-label">{{getStr('Close')}}</span>
         </button>
     </div>
 </div>

--- a/src/app/scopes-dialog.component.html
+++ b/src/app/scopes-dialog.component.html
@@ -9,7 +9,7 @@
         <div id="scopes-list-table-container">
             <table class="ms-Table" id="scopes-list-table">
                 <tr *ngFor="let scope of scopes">
-                    <td>
+                    <td class="scopeRow">
                         <div class="c-checkbox">
                             <label class="c-label">
                                 <input type="checkbox" [disabled]="scope.name == 'openid'" (change)="toggleScopeEnabled(scope)" name="checkboxId1" value="value1"

--- a/src/app/scopes-dialog.component.ts
+++ b/src/app/scopes-dialog.component.ts
@@ -2,7 +2,7 @@
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 
-import { Component, AfterViewInit } from '@angular/core';
+import { Component, AfterViewInit, ViewChild, ElementRef } from '@angular/core';
 import { GraphExplorerComponent } from "./GraphExplorerComponent";
 import { PermissionScopes } from "./scopes";
 import { PermissionScope } from "./base";
@@ -16,21 +16,89 @@ declare let fabric, mwf;
 })
 export class ScopesDialogComponent extends GraphExplorerComponent implements AfterViewInit {
 
+  // Use this to get a handle on the scopes-list-table-container element.
+  @ViewChild('scopesListTableContainer') scopesTableList: ElementRef;
+
+  // Contains the scopes list table height. The maximum height value is 451px.
+  scopesListTableHeight: String;
+
+  // Flags for changing the scopes list table height.
+  hasChangedScopeListHeight: Boolean = false;
+  hasRequestedAdminConsent: Boolean = false;
+
+  // Updates the style.height of the scopes-list-table-container element. 
+  getScopesListTableHeight(): String {
+    this.scopesListTableHeight = window.getComputedStyle(this.scopesTableList.nativeElement, null).getPropertyValue("height");
+    return this.scopesListTableHeight;
+  }
+
   getScopeLabel(scopeName: String): String {
     return scopeName + " scope";
   }
 
   ngAfterViewInit(): void {
     ScopesDialogComponent.setScopesEnabledTarget();
-    window['launchPermissionsDialog'] = ScopesDialogComponent.showDialog
+    window['launchPermissionsDialog'] = ScopesDialogComponent.showDialog;
+    this.scopesListTableHeight = window.getComputedStyle(this.scopesTableList.nativeElement, null).getPropertyValue("height");
   }
 
+  /** 
+   * Indicates whether the scope list has been changed.
+   * @returns {boolean} A value of true indicates that a scope has been added or removed from the scope list.
+  */
   scopeListIsDirty(): boolean {
-    return PermissionScopes.filter((s) => s.enabled !== s.enabledTarget).length > 0;
+
+    // Determine whether the scope list has changed. The scope list has changed if isDirty = true.
+    let isDirty = PermissionScopes.filter((s) => s.enabled !== s.enabledTarget).length > 0;
+
+    // Reduce the size of the scopes table list by the size of the message bar. We only want to make this
+    // change the first time that the selected scope list is changed. 
+    if (isDirty && !this.hasChangedScopeListHeight) {
+
+      // Convert the table height from string to number.
+      var currentHeight: number = Number(this.scopesListTableHeight.replace(/px/, "")).valueOf();
+
+      // Update the table height based on the height of the message bar that's displayed when the scope list is dirty.
+      // This should keep the buttons from moving below the viewport as long as the component is showing in the viewport.
+      var updatedHeight: number = currentHeight - 60;
+
+      // Convert the updated height to a string and set the scopes list table height style.
+      this.scopesTableList.nativeElement.style.height = updatedHeight.toString() + "px";
+
+      // We only want to adjust the height one time after making a change to the selected scope list.
+      this.hasChangedScopeListHeight = true;
+    }
+
+    return isDirty;
   }
 
+  /** 
+   * Indicates whether an admin scope has been selected.
+   * @returns {boolean} A value of true indicates that a scope that requires admin consent has been selected.
+  */
   requestingAdminScopes(): boolean {
-    return PermissionScopes.filter((s) => s.admin && s.enabledTarget).length > 0;
+
+    // Determine whether a scope that requires admin consent has been selected. An admin consent scope has been selected if isDirty = true.
+    let isDirty = PermissionScopes.filter((s) => s.admin && s.enabledTarget).length > 0;
+
+    // Reduce the size of the scopes table list by the size of the message bar. We only want to make this
+    // change the first time that the selected scope list is changed. 
+    if (isDirty && !this.hasRequestedAdminConsent) {
+      // Convert the table height from string to number.
+      var currentHeight: number = Number(this.scopesListTableHeight.replace(/px/, "")).valueOf();
+
+      // Update the table height based on the height of the message bar that's displayed when an admin consent scope is selected.
+      // This should keep the buttons from moving below the viewport as long as the component is showing in the viewport.
+      var updatedHeight: number = currentHeight - 135;
+
+      // Convert the updated height to a string and set the scopes list table height style.
+      this.scopesTableList.nativeElement.style.height = updatedHeight.toString() + "px";
+
+      // We only want to adjust the height one time after making a change to the selected scope list.
+      this.hasRequestedAdminConsent = true;
+    }
+
+    return isDirty;
   }
 
   toggleScopeEnabled(scope: PermissionScope) {


### PR DESCRIPTION
e6db649 Added labels for the scopes checkboxes so that screen readers can identify the state and name of the checkbox.

7e44905 Provide onHover context for each scope in the list. 

01ea5f6 Fix so that the *Modify Permissions* and *Close* buttons do not get pushed beyond the viewport of the browser when the message boxes are shown to provide guidance on needing to reconsent or get admin consent for newly selected scopes.

@kaevne I tried putting a table under the ms-Dialog-content div, that had three rows:
R1 with the scopes-list-table-container
R2 scopeListIsDirty message box
R3 requestAdminScopes message box
It still had the original behavior. Like you said, we'd need to do some other CSS work to make the right solution. But this is part of a bigger issue where we'd need to make the entire dialog responsive to smaller screens. So that's why I'm going with this fix for now.