### PR TITLE
Fix accessibility for rocket image

### DIFF
--- a/src/app/sidebar.component.html
+++ b/src/app/sidebar.component.html
@@ -15,8 +15,9 @@
 
     <div class="c-drawer">
         <button class="c-glyph" aria-expanded="true" aria-controls="refineDrawer">
-            <span class="c-heading-5 panel-header" tabindex="0">
-                <img id="getting-started-svg" src="{{getAssetPath('assets/images/rocket1.svg')}}" alt="Image of a key that represents authentication"/>{{getStr('Sample Queries')}}</span>
+            <span class="c-heading-5 panel-header">
+                <img id="getting-started-svg" src="{{getAssetPath('assets/images/rocket1.svg')}}" title="Image of a rocket that represents"
+                />{{getStr('Sample Queries')}}</span>
         </button>
         <div id="refineDrawer" class="panel-content">
             <div id="sample-queries-scroll">


### PR DESCRIPTION
Removed the tabIndex since we only want the drawer element as an  interactive element. Changed the alt to title so that Narrator reads the title and button name as "Image of a rocket that represents sample queries".