### PR TITLE
 Make sample category panel active when **show more samples** is selected

### DIFF
--- a/src/app/sample-categories-panel.component.html
+++ b/src/app/sample-categories-panel.component.html
@@ -1,6 +1,7 @@
 <div id="sample-categories-panel" class="ms-Panel ms-Panel--lg">
-    <button class="ms-Panel-closeButton ms-PanelAction-close" aria-label="Close sample categories" tabindex="0">
-        <i class="ms-Panel-closeIcon ms-Icon ms-Icon--Cancel"></i>
+    <button id="closeSampleCategories" class="ms-Panel-closeButton ms-PanelAction-close" aria-label="Close sample categories">
+        <i class="ms-Panel-closeIcon ms-Icon ms-Icon--Cancel">
+        </i>
     </button>
     <div class="ms-Panel-contentInner">
         <p class="ms-Panel-headerText">{{getStr('Sample Categories')}}</p>

--- a/src/app/sample-categories-panel.component.ts
+++ b/src/app/sample-categories-panel.component.ts
@@ -18,8 +18,8 @@ export class SampleCategoriesPanelComponent extends GraphExplorerComponent imple
 
     ngAfterViewInit(): void {
         mwf.ComponentFactory.create([{
-            'component': mwf.Toggle,
-        }])
+            'component': mwf.Toggle
+        }]);
     }
 
     toggleCategory(category: SampleQueryCategory) {

--- a/src/app/sidebar.component.ts
+++ b/src/app/sidebar.component.ts
@@ -38,7 +38,6 @@ export class SidebarComponent extends GraphExplorerComponent implements AfterVie
 
         // Set the focus on the first actionable control in the sampleCategoryPanel.
         (document.querySelector("#closeSampleCategories") as any).focus();
-        console.log(document.activeElement);
     }
 
     manageHistory() {

--- a/src/app/sidebar.component.ts
+++ b/src/app/sidebar.component.ts
@@ -10,9 +10,9 @@ import { SampleCategories } from "./getting-started-queries";
 declare let fabric;
 
 @Component({
-  selector: 'sidebar',
-  templateUrl: './sidebar.component.html',
-  styleUrls: ['./sidebar.component.css']
+    selector: 'sidebar',
+    templateUrl: './sidebar.component.html',
+    styleUrls: ['./sidebar.component.css']
 })
 export class SidebarComponent extends GraphExplorerComponent implements AfterViewInit {
     sampleCategoryPanel: Element;
@@ -30,12 +30,15 @@ export class SidebarComponent extends GraphExplorerComponent implements AfterVie
 
     }
 
-    categories:SampleQueryCategory[] = SampleCategories
+    categories: SampleQueryCategory[] = SampleCategories
 
     manageCategories() {
         // open sample category panel
         new fabric['Panel'](this.sampleCategoryPanel); // tslint:disable-line
 
+        // Set the focus on the first actionable control in the sampleCategoryPanel.
+        (document.querySelector("#closeSampleCategories") as any).focus();
+        console.log(document.activeElement);
     }
 
     manageHistory() {
@@ -46,14 +49,14 @@ export class SidebarComponent extends GraphExplorerComponent implements AfterVie
 
     closePanels() {
         try {
-            (document.querySelector("#history-panel .ms-Panel-closeButton") as any).click()
-        } catch(e) {
+            (document.querySelector("#history-panel .ms-Panel-closeButton") as any).click();
+        } catch (e) {
 
         }
 
         try {
-            (document.querySelector("#sample-categories-panel .ms-Panel-closeButton") as any).click()
-        } catch(e) {
+            (document.querySelector("#sample-categories-panel .ms-Panel-closeButton") as any).click();
+        } catch (e) {
 
         }
     };


### PR DESCRIPTION
Without this change, it is not possible to tab through and select the sample groups with the keyboard.