### PR TITLE
Narrator screeen reader now prefixes category name per query

### DIFF
--- a/src/app/queryrow.component.html
+++ b/src/app/queryrow.component.html
@@ -1,5 +1,6 @@
 <div class="api-query" (click)="handleQueryClick()" onclick="this.blur();" (keydown)="queryKeyDown($event)" [attr.title]="getTitle()"
-    [class.restrict]="!isAuthenticated() && query.method != 'GET'" tabindex="0" role="button">
+    [class.restrict]="!isAuthenticated() && query.method != 'GET'" tabindex="0" role="button" [attr.aria-labelledby]="getAriaLabelledBy()"
+    [attr.id]="getQueryButtonId()">
     <div class="row-1" [attr.aria-label]="getAriaLabelForSampleRow()">
         <method-badge [query]="query"></method-badge>
         <div class="query">{{getQueryText()}}</div>
@@ -11,7 +12,6 @@
             target="_blank" aria-label="Documentation">
             <i class="ms-Icon ms-Icon--Page"></i>
         </a>
-
     </div>
     <ng-content></ng-content>
 </div>

--- a/src/app/queryrow.component.ts
+++ b/src/app/queryrow.component.ts
@@ -17,6 +17,7 @@ import { QueryRunnerService } from "./query-runner.service";
 })
 export class QueryRowComponent extends GraphExplorerComponent {
 
+    @Input() category: string;
     @Input() query: SampleQuery;
 
     constructor(public queryRunnerService: QueryRunnerService) {
@@ -35,6 +36,20 @@ export class QueryRowComponent extends GraphExplorerComponent {
 
     getQueryText() {
         return getShortQueryText(this.query);
+    }
+
+    /**
+     * @returns The identifier of query button element.
+     */
+    getQueryButtonId(): string {
+        return (this.query.method + " " + this.getQueryText()).replace(/\s+/g, '-').toLowerCase();
+    }
+
+    /**
+     * @returns The value for the aria-labelledby element that is used by AT.
+     */
+    getAriaLabelledBy(): string {
+        return this.category + " " + this.getQueryButtonId();
     }
 
     getAriaLabelForSampleRow() {

--- a/src/app/sidebar.component.html
+++ b/src/app/sidebar.component.html
@@ -23,9 +23,9 @@
             <div id="sample-queries-scroll">
                 <div *ngFor="let category of categories" class="sample-category" [hidden]="!category.enabled">
                     <div>
-                        <span class="category-heading">{{getStr(category.title)}}</span>
+                        <span class="category-heading" [attr.id]="idifyCategory(category.title)">{{getStr(category.title)}}</span>
                     </div>
-                    <query-row [query]="query" *ngFor="let query of category.queries"></query-row>
+                    <query-row [query]="query" [category]="idifyCategory(category.title)" *ngFor="let query of category.queries"></query-row>
                 </div>
             </div>
             <a href="#" id="manage-categories" class="c-hyperlink" tabindex=0 (click)="manageCategories()">{{getStr('show more samples')}}</a>

--- a/src/app/sidebar.component.ts
+++ b/src/app/sidebar.component.ts
@@ -6,6 +6,7 @@ import { Component, AfterViewInit } from '@angular/core';
 import { SampleQueryCategory } from "./base";
 import { GraphExplorerComponent } from "./GraphExplorerComponent";
 import { SampleCategories } from "./getting-started-queries";
+import { QueryRowComponent } from './queryrow.component';
 
 declare let fabric;
 
@@ -28,6 +29,15 @@ export class SidebarComponent extends GraphExplorerComponent implements AfterVie
             }
         });
 
+    }
+
+    /**
+     * idifyCategory
+     * @param categoryTitle The sample category title that will be changed into an element id.
+     * @returns A sample category title as an ID.
+     */
+    idifyCategory(categoryTitle: string): string {
+        return categoryTitle.replace(/\s+/g, '-').toLowerCase();
     }
 
     categories: SampleQueryCategory[] = SampleCategories

--- a/src/app/sidebar.component.ts
+++ b/src/app/sidebar.component.ts
@@ -6,7 +6,6 @@ import { Component, AfterViewInit } from '@angular/core';
 import { SampleQueryCategory } from "./base";
 import { GraphExplorerComponent } from "./GraphExplorerComponent";
 import { SampleCategories } from "./getting-started-queries";
-import { QueryRowComponent } from './queryrow.component';
 
 declare let fabric;
 


### PR DESCRIPTION
* Each category heading has an identifier.
* Each api-query button gets an identifier and an aria-labelledby attribute.

These changes support the Narrator AT. The following image shows the attributes generated by these changes.

![image](https://user-images.githubusercontent.com/8527305/42003716-b3511d8a-7a21-11e8-9226-9ba162ccfde9.png)

Steps to see in action:
1. Clone and checkout the *at-categoryLabels* branch.
2. `npm install`.
3. `npm start`.
4. Open `http://localhost:3000` in Edge.
5. Turn on Narrator.
6. Tab to the *GET my profile* query.
7. You should hear it say "Getting started get my profile".

