### PR TITLE
Pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+
+## Overview
+
+Brief description of what this PR does, and why it is needed.
+
+### Demo
+
+Optional. Screenshots, `curl` examples, etc.
+
+### Notes
+
+Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.
+
+## Testing Instructions
+
+* How to test this PR
+* Prefer bulleted description
+* Start after checking out this branch
+* Include any setup required, such as bundling scripts, restarting services, etc.
+* Include test case, and expected output

--- a/secrets.sample.js
+++ b/secrets.sample.js
@@ -1,0 +1,2 @@
+// You can register your app and get a client ID at https://apps.dev.microsoft.com
+window.ClientId = "<insert id here>";

--- a/secrets.sample.js
+++ b/secrets.sample.js
@@ -1,2 +1,0 @@
-// You can register your app and get a client ID at https://apps.dev.microsoft.com
-window.ClientId = "<insert id here>";


### PR DESCRIPTION
## What does this PR do
Adds a pull request template

## Notes
Reviewers have a  difficult time figuring out what the PR does and how to test the changes when there is little description on what the PR does. The PR template should act as a guideline for providing context on what the PR does.

This will lessen the cognitive load for the reviewers.

You can learn more about this template [here](https://www.azavea.com/blog/2017/05/08/github-pull-request-template-workflow/)
