### PR TITLE
Send newly requested scopes; do not send previously consented scopes

### DIFF
--- a/src/app/authentication/auth.ts
+++ b/src/app/authentication/auth.ts
@@ -90,7 +90,8 @@ export function initAuth(options: IExplorerOptions, apiService: GraphService, ch
       const scopes = getScopes();
       scopes.push('openid');
       for (const scope of PermissionScopes) {
-        scope.enabled = scope.enabledTarget = scopes.indexOf(scope.name.toLowerCase()) !== -1;
+        // scope.consented indicates that the user or admin has previously consented to the scope.
+        scope.consented = scopes.indexOf(scope.name.toLowerCase()) !== -1;
       }
     }
   });
@@ -190,7 +191,7 @@ export function haveValidAccessToken(): boolean {
   return session && session.access_token && session.expires > currentTime;
 }
 
-window['tokenPlease'] = function() {
+window['tokenPlease'] = function () {
   const authResponse = hello('msft').getAuthResponse();
   if (authResponse) {
     return authResponse.access_token;

--- a/src/app/base.ts
+++ b/src/app/base.ts
@@ -32,19 +32,39 @@ export type AuthenticationStatus = 'anonymous' | 'authenticating' | 'authenticat
 
 export type RequestType = 'GET' | 'PUT' | 'POST' | 'GET_BINARY' | 'POST' | 'PATCH' | 'DELETE';
 
+/***
+ * Represents a scope.
+ */
 export interface IPermissionScope {
-  name: string;
-  description: string;
-  longDescription: string;
-  preview: boolean;
-  admin: boolean;
-
-  enabled?: boolean;
-
-  /**
-   * Used in the scopes dialog for checking/unchecking before scope is actually enabled in the token.
-   */
-  enabledTarget?: boolean;
+    /**
+     * The scope name.
+     */
+    name: string;
+    /**
+     * A short description of the scope.
+     */
+    description: string;
+    /**
+     * A long description of the scope.
+     */
+    longDescription: string;
+    /**
+     * Specifies whether the scope is currently in preview.
+     */
+    preview: boolean;
+    /**
+     * Specifies whether the property is only consent-able via admin consent.
+     */
+    admin: boolean;
+    /**
+     * Specifies whether the user has already consented to the scope.
+     */
+    consented?: boolean;
+    /**
+     * Specifies whether the user wants to request this scope. Used in the scopes
+     * dialog for checking/unchecking before scope is actually enabled in the token.
+     */
+    requested?: boolean;
 }
 
 export interface IGraphApiCall {

--- a/src/app/scopes-dialog/scopes-dialog.component.html
+++ b/src/app/scopes-dialog/scopes-dialog.component.html
@@ -14,18 +14,17 @@
                     <td class="scopeRow">
                         <div class="c-checkbox">
                             <label class="c-label">
-                                <input
-                                    type="checkbox"
-                                    [disabled]="scope.enabled"
-                                    (change)="toggleScopeEnabled(scope)"
-                                    name="checkboxId1"
-                                    value="value1"
+                                <!-- scope.consented indicates that the user or admin has previously consented to the scope.-->
+                                <input type="checkbox" 
+                                    [disabled]="scope.consented"
+                                    (change)="toggleRequestScope(scope)"
+                                    name="checkboxId1" 
+                                    value="value1" 
                                     [attr.aria-label]="getScopeLabel(scope.name)"
                                     [tabindex]=""
-                                >
-
+                                    >
                                 <span aria-hidden="true" [title]="scope.description">{{scope.name}}
-                                    <i class="consented-label" *ngIf="scope.enabled">{{getStr('Consented')}}</i>
+                                    <i class="consented-label" *ngIf="scope.consented">{{getStr('Consented')}}</i>
                                     <i class="preview-label" *ngIf="scope.preview">{{getStr('Preview')}}</i>
                                 </span>
                             </label>


### PR DESCRIPTION
## Overview

base.ts - Renamed fields and added comments to IPermissionScope.
auth.ts - Removed setting of the scope.requested field. That value is UI driven.
scopes-dialog.component - Removed setScopesEnabledTarget, no longer used. Renamed fields on IPermissionScope. Properly filter the set of requested scopes so that we only request new, incremental scopes 

### Demo

![image](https://user-images.githubusercontent.com/8527305/47533284-0b256a80-d868-11e8-8372-daaa1bb36dd8.png)

Fixes #182 