### PR TITLE
Accessible modify permissions

### DIFF
--- a/src/app/scopes-dialog/scopes-dialog.component.css
+++ b/src/app/scopes-dialog/scopes-dialog.component.css
@@ -36,7 +36,7 @@
 }
 
 .c-checkbox input[type=checkbox]:focus+span:before {
-    outline: none !important;
+    outline: 1.5px solid #0078d7;;
 }
 
 label.c-label {

--- a/src/app/scopes-dialog/scopes-dialog.component.css
+++ b/src/app/scopes-dialog/scopes-dialog.component.css
@@ -36,7 +36,7 @@
 }
 
 .c-checkbox input[type=checkbox]:focus+span:before {
-    outline: 1.5px solid #0078d7;;
+    outline: 2px solid #0078d7;
 }
 
 label.c-label {

--- a/src/app/scopes-dialog/scopes-dialog.component.html
+++ b/src/app/scopes-dialog/scopes-dialog.component.html
@@ -20,7 +20,7 @@
             tabindex="0">
             <table class="ms-Table" id="scopes-list-table">
                 <tr *ngFor="let scope of scopes">
-                    <td class="scopeRow" [tabindex]="getTabIndex(scope)">
+                    <td class="scopeRow">
                         <div class="c-checkbox">
                             <label class="c-label">
                                 <!-- scope.consented indicates that the user or admin has previously consented to the scope.-->

--- a/src/app/scopes-dialog/scopes-dialog.component.html
+++ b/src/app/scopes-dialog/scopes-dialog.component.html
@@ -1,8 +1,8 @@
 <div class="ms-Dialog center-dialog ms-Dialog--close" id="scopes-dialog">
-    <button class="ms-Dialog-button ms-Dialog-buttonClose">
+    <button class="ms-Dialog-button ms-Dialog-buttonClose" tabindex="0" (keydown)="focusOnLastElement($event, lastElement)" #firstElement>
         <i class="ms-Icon ms-Icon--Cancel"></i>
     </button>
-    <div class="ms-Dialog-title">{{getStr('modify permissions')}}</div>
+    <div tabindex="0" class="ms-Dialog-title">{{getStr('modify permissions')}}</div>
     <p class="ms-Dialog-subText">Select different
         <a class="ms-Link" href="https://developer.microsoft.com/graph/docs/concepts/permissions_reference" target="_blank">permissions</a>
         to try out Microsoft Graph API endpoints.</p>
@@ -11,19 +11,18 @@
         <div id="scopes-list-table-container" #scopesListTableContainer [style.height.px]="getScopesListTableHeight()">
             <table class="ms-Table" id="scopes-list-table">
                 <tr *ngFor="let scope of scopes">
-                    <td class="scopeRow">
+                    <td class="scopeRow" [tabindex]="getTabIndex(scope)" >
                         <div class="c-checkbox">
                             <label class="c-label">
                                 <!-- scope.consented indicates that the user or admin has previously consented to the scope.-->
-                                <input type="checkbox" 
+                                <input type="checkbox"
                                     [disabled]="scope.consented"
                                     (change)="toggleRequestScope(scope)"
-                                    name="checkboxId1" 
-                                    value="value1" 
+                                    name="checkboxId1"
+                                    value="value1"
                                     [attr.aria-label]="getScopeLabel(scope.name)"
-                                    [tabindex]=""
                                     >
-                                <span aria-hidden="true" [title]="scope.description">{{scope.name}}
+                                <span aria-hidden="true" [title]="scope.description" >{{scope.name}}
                                     <i class="consented-label" *ngIf="scope.consented">{{getStr('Consented')}}</i>
                                     <i class="preview-label" *ngIf="scope.preview">{{getStr('Preview')}}</i>
                                 </span>
@@ -69,10 +68,10 @@
         </div>
     </div>
     <div class="ms-Dialog-actions">
-        <button class="ms-Button ms-Dialog-action ms-Button--primary" [disabled]="!scopeListIsDirty()" (click)="getNewAccessToken()">
+        <button class="ms-Button ms-Dialog-action ms-Button--primary" [disabled]="!scopeListIsDirty()" (click)="getNewAccessToken()" tabindex="0">
             <span class="ms-Button-label" style="text-transform: capitalize;">{{getStr('modify permissions')}}</span>
         </button>
-        <button class="ms-Button ms-Dialog-action">
+        <button class="ms-Button ms-Dialog-action" tabindex="0" #lastElement (keydown.tab)="focusOnFirstElement(firstElement)" tabindex="0">
             <span class="ms-Button-label">{{getStr('Close')}}</span>
         </button>
     </div>

--- a/src/app/scopes-dialog/scopes-dialog.component.html
+++ b/src/app/scopes-dialog/scopes-dialog.component.html
@@ -1,28 +1,32 @@
-<div class="ms-Dialog center-dialog ms-Dialog--close" id="scopes-dialog">
-    <button class="ms-Dialog-button ms-Dialog-buttonClose" tabindex="0" (keydown)="focusOnLastElement($event, lastElement)" #firstElement>
+<div class="ms-Dialog center-dialog ms-Dialog--close" id="scopes-dialog" tabindex="0">
+    <!--
+    This empty tag is a workaround for fixing an off by one error.
+
+    When focus is on the CLOSE button on the bottom right of the dialog and the user presses TAB focus would skip to the dialog title.
+
+    Having this empty tag means that focus would skip to the CLOSE icon instead of the dialog title.
+    -->
+    <div #firstElement tabindex="0"></div>
+    <button class="ms-Dialog-button ms-Dialog-buttonClose" tabindex="0" (keydown)="focusOnLastElement($event, lastElement)"
+        autofocus>
         <i class="ms-Icon ms-Icon--Cancel"></i>
     </button>
     <div tabindex="0" class="ms-Dialog-title">{{getStr('modify permissions')}}</div>
-    <p class="ms-Dialog-subText">Select different
+    <p class="ms-Dialog-subText" tabindex="0">Select different
         <a class="ms-Link" href="https://developer.microsoft.com/graph/docs/concepts/permissions_reference" target="_blank">permissions</a>
         to try out Microsoft Graph API endpoints.</p>
     <div class="ms-Dialog-content">
-
-        <div id="scopes-list-table-container" #scopesListTableContainer [style.height.px]="getScopesListTableHeight()">
+        <div id="scopes-list-table-container" #scopesListTableContainer [style.height.px]="getScopesListTableHeight()"
+            tabindex="0">
             <table class="ms-Table" id="scopes-list-table">
                 <tr *ngFor="let scope of scopes">
-                    <td class="scopeRow" [tabindex]="getTabIndex(scope)" >
+                    <td class="scopeRow" [tabindex]="getTabIndex(scope)">
                         <div class="c-checkbox">
                             <label class="c-label">
                                 <!-- scope.consented indicates that the user or admin has previously consented to the scope.-->
-                                <input type="checkbox"
-                                    [disabled]="scope.consented"
-                                    (change)="toggleRequestScope(scope)"
-                                    name="checkboxId1"
-                                    value="value1"
-                                    [attr.aria-label]="getScopeLabel(scope.name)"
-                                    >
-                                <span aria-hidden="true" [title]="scope.description" >{{scope.name}}
+                                <input type="checkbox" [disabled]="scope.consented" (change)="toggleRequestScope(scope)"
+                                    name="checkboxId1" value="value1" [attr.aria-label]="getScopeLabel(scope.name)">
+                                <span aria-hidden="true" [title]="scope.description">{{scope.name}}
                                     <i class="consented-label" *ngIf="scope.consented">{{getStr('Consented')}}</i>
                                     <i class="preview-label" *ngIf="scope.preview">{{getStr('Preview')}}</i>
                                 </span>
@@ -68,11 +72,21 @@
         </div>
     </div>
     <div class="ms-Dialog-actions">
-        <button class="ms-Button ms-Dialog-action ms-Button--primary" [disabled]="!scopeListIsDirty()" (click)="getNewAccessToken()" tabindex="0">
+        <button class="ms-Button ms-Dialog-action ms-Button--primary" [disabled]="!scopeListIsDirty()" (click)="getNewAccessToken()"
+            tabindex="0">
             <span class="ms-Button-label" style="text-transform: capitalize;">{{getStr('modify permissions')}}</span>
         </button>
-        <button class="ms-Button ms-Dialog-action" tabindex="0" #lastElement (keydown.tab)="focusOnFirstElement(firstElement)" tabindex="0">
+        <button class="ms-Button ms-Dialog-action" tabindex="0" tabindex="0" (keydown.tab)="focusOnFirstElement(firstElement)">
             <span class="ms-Button-label">{{getStr('Close')}}</span>
         </button>
+        <!--
+        This empty tag is a workaround for fixing an off by one error.
+
+        When focus is on the X icon on the top right of the modal and the user presses SHIFT + TAB focus would skip to the button
+        just before the close button.
+
+        Having this empty tag means that focus would skip to the CLOSE button instead of the the Modify Permission button
+        -->
+        <div tabindex="0" #lastElement></div>
     </div>
 </div>

--- a/src/app/scopes-dialog/scopes-dialog.component.html
+++ b/src/app/scopes-dialog/scopes-dialog.component.html
@@ -76,7 +76,7 @@
             tabindex="0">
             <span class="ms-Button-label" style="text-transform: capitalize;">{{getStr('modify permissions')}}</span>
         </button>
-        <button class="ms-Button ms-Dialog-action" tabindex="0" tabindex="0" (keydown.tab)="focusOnFirstElement(firstElement)">
+        <button class="ms-Button ms-Dialog-action" tabindex="0" (keydown.tab)="focusOnFirstElement(firstElement)">
             <span class="ms-Button-label">{{getStr('Close')}}</span>
         </button>
         <!--

--- a/src/app/scopes-dialog/scopes-dialog.component.ts
+++ b/src/app/scopes-dialog/scopes-dialog.component.ts
@@ -180,12 +180,30 @@ export class ScopesDialogComponent extends GraphExplorerComponent implements Aft
 
   public static showDialog() { // tslint:disable-line
 
-    const el = document.querySelector('#scopes-dialog');
-    const fabricDialog = new fabric.Dialog(el);
+    const scopesDialog = document.querySelector('#scopes-dialog');
+    const fabricDialog = new fabric.Dialog(scopesDialog);
     fabricDialog.open();
 
     mwf.ComponentFactory.create([{
       component: mwf.Checkbox,
     }]);
+
+    (scopesDialog.childNodes[1] as any).focus();
+  }
+
+  public focusOnFirstElement(firstElement: Element) {
+    (firstElement as any).focus();
+  }
+
+  public focusOnLastElement(event: any, lastElement: Element) {
+    if (event.shiftKey && event.keyCode === 9) {
+      (lastElement as any).focus();
+    }
+  }
+
+  public getTabIndex(scope) {
+    // Consented scopes appear as disabled elements. Users should not be able to tab through them.
+    const isDisabled = scope.consented;
+    return isDisabled ? '-1' : '0';
   }
 }

--- a/src/app/scopes-dialog/scopes-dialog.component.ts
+++ b/src/app/scopes-dialog/scopes-dialog.component.ts
@@ -187,8 +187,6 @@ export class ScopesDialogComponent extends GraphExplorerComponent implements Aft
     mwf.ComponentFactory.create([{
       component: mwf.Checkbox,
     }]);
-
-    (scopesDialog.childNodes[1] as any).focus();
   }
 
   public focusOnFirstElement(firstElement: Element) {
@@ -202,7 +200,8 @@ export class ScopesDialogComponent extends GraphExplorerComponent implements Aft
   }
 
   public getTabIndex(scope) {
-    // Consented scopes appear as disabled elements. Users should not be able to tab through them.
+    // Consented scopes appear as disabled elements.
+    // Users should not be able to tab through them.
     const isDisabled = scope.consented;
     return isDisabled ? '-1' : '0';
   }

--- a/src/app/scopes-dialog/scopes-dialog.component.ts
+++ b/src/app/scopes-dialog/scopes-dialog.component.ts
@@ -187,6 +187,11 @@ export class ScopesDialogComponent extends GraphExplorerComponent implements Aft
     mwf.ComponentFactory.create([{
       component: mwf.Checkbox,
     }]);
+
+    // We are explicitly focusing on the close icon button here despite setting the autofocus property.
+    // This is because Edge does not give this element focus even with the autofocus property set.
+    // See: https://stackoverflow.com/questions/51867504/edge-how-to-make-autofocus-work-with-refresh-button
+    (scopesDialog.childNodes[2] as any).focus();
   }
 
   public focusOnFirstElement(firstElement: Element) {


### PR DESCRIPTION
## Overview

This pull request makes the modify permissions dialog more accessible.

### Demo

![modify permissions](https://user-images.githubusercontent.com/12011447/47907715-d1beb180-de9c-11e8-9bfe-7f41dd04abb1.JPG)

### Notes

* Edge does not handle the autofocus property properly. So I had to explicitly set the focus.
* I also had an off by one error when a user presses tab on the last element in the dialog or SHIFT + TAB in the first element. Adding empty tags seemed like a decent work around for this bug.

## Testing Instructions

* Launch graph explorer
* Log In 
* Click on modify permissions
* Turn narrator on
* Tab through the dialog