### PR TITLE
Generate prod build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,12 +23,17 @@ steps:
     displayName: 'Runs tests'
   - script: |
       npm run import:samples
+    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/dev'))
+
     displayName: 'Imports samples'
   - script: |
       npm run import:loc-strings
+    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/dev'))
     displayName: 'Imports loc-strings'
+
   - script: |
       npm run build:prod
+    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/dev'))
     displayName: 'Runs a production build'
 
 
@@ -40,5 +45,6 @@ steps:
       destination: 'azureBlob'
       storage: 'graphstagingblobstorage'
       containerName: 'staging/vendor/bower_components/explorer/dist'
+    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/dev'))
     displayName: 'Stage'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,10 +14,23 @@ steps:
 
   - script: |
       npm install
+    displayName: 'npm install'
+  - script: |
       npm run lint
-      npm run test
+    displayName: 'Runs linting checks'
+  - script: |
+      npm test
+    displayName: 'Runs tests'
+  - script: |
+      npm run import:samples
+    displayName: 'Imports samples'
+  - script: |
+      npm run import:loc-strings
+    displayName: 'Imports loc-strings'
+  - script: |
       npm run build:prod
-    displayName: 'npm install and build'
+    displayName: 'Runs a production build'
+
 
   - task: AzureFileCopy@2
     inputs:


### PR DESCRIPTION
## Overview
1. Generate production build
2. Uploads when changes are merged into develop.

Brief description of what this PR does, and why it is needed.

### Demo

N/A

### Notes

I noticed that the CI was not updating the latest changes to Azure Blob Storage. For some reason specifying the scripts in the format below only ran the first in the list.
```
- scripts:
   npm install
   npm test
```
Only `npm install` would run. This explains why the CI was not uploading the latest changes since `npm run build:prod` would not have been executed. 

I also added a condition to make sure that we are only generating the production build when changes are merged into dev instead of every time a PR is made.