### PR TITLE
adds missing slash to the base url

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -33,7 +33,7 @@ import { SidebarComponent } from './sidebar/sidebar.component';
   providers: [{
     provide: APP_BASE_HREF,
     useValue: window.location.hostname === 'localhost' ?
-      '/' : `/${(window.location.pathname.split('/')[1] || '')}graph/graph-explorer/`,
+      '/' : `/${(window.location.pathname.split('/')[1] || '')}/graph/graph-explorer/`,
   }],
   declarations: [AppComponent, AriaSelectedMSPivotLinkDirective, ResponseStatusBarComponent,
     AuthenticationComponent, SidebarComponent, QueryRowComponent, MainColumnComponent, HistoryRowComponent,


### PR DESCRIPTION
## Overview

Checks the hosting location and appends appropriate suffixes

## Notes
To view the process locally, the only assumption is that you have installed a tunneling software e.g. ngrok. In your application portal, set the logout url to the one generated by ngrok. eg https://92832de0.ngrok.io/logout

## Testing Instructions

- Run Graph Explorer and log in
- Log in somewhere else with the same account
- Logout of the other application
- Notice that you have been logged out of Graph Explorer