### PR TITLE
Increases the z-index property of ms-PanelHost

### DIFF
--- a/src/custom.css
+++ b/src/custom.css
@@ -93,7 +93,7 @@ api-explorer .c-select-menu>a:after, api-explorer .c-select-menu>button:after {
 
 /* frontdoor */
 .ms-PanelHost {
-    z-index: 999;
+    z-index: 3000002;
 }
 
 #deltaUi {


### PR DESCRIPTION
## Overview

Increases the z-index property of ms-PanelHost

### Demo

N/A

### Notes

The z-index of the sign in button in `developer.microsoft.com/en-US/graph` is `3000001`. To stop it from showing in the panel, the panel's z-index has been set to `3000002`

## Testing Instructions

N/A