### PR TITLE
Add the ability to override the tenant id

### DIFF
--- a/secrets.sample.js
+++ b/secrets.sample.js
@@ -1,2 +1,3 @@
 // You can register your app and get a client ID at https://apps.dev.microsoft.com
 window.ClientId = "<insert id here>";
+window.TenantId = "<insert id here>";

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -46,6 +46,7 @@ export class AppComponent extends GraphExplorerComponent implements OnInit, Afte
 
     public static Options: IExplorerOptions = {
         ClientId: '',
+        TenantId: 'common',
         Language: 'en-US',
         DefaultUserScopes: 'openid profile User.ReadWrite User.ReadBasic.All Sites.ReadWrite.All Contacts.ReadWrite ' +
             'People.Read Notes.ReadWrite.All Tasks.ReadWrite Mail.ReadWrite Files.ReadWrite.All Calendars.ReadWrite',

--- a/src/app/authentication/auth.ts
+++ b/src/app/authentication/auth.ts
@@ -16,8 +16,8 @@ export function initAuth(options: IExplorerOptions, apiService: GraphService, ch
     msft: {
       oauth: {
         version: 2,
-        auth: options.AuthUrl + '/common/oauth2/v2.0/authorize',
-        grant: options.AuthUrl + '/common/oauth2/v2.0/token',
+        auth: options.AuthUrl + '/' + options.TenantId + '/oauth2/v2.0/authorize',
+        grant: options.AuthUrl + '/' + options.TenantId + '/oauth2/v2.0/token',
       },
       scope_delim: ' ',
 
@@ -27,8 +27,8 @@ export function initAuth(options: IExplorerOptions, apiService: GraphService, ch
     }, msft_admin_consent: {
       oauth: {
         version: 2,
-        auth: options.AuthUrl + '/common/adminconsent',
-        grant: options.AuthUrl + '/common/oauth2/v2.0/token',
+        auth: options.AuthUrl + '/' + options.TenantId + '/adminconsent',
+        grant: options.AuthUrl + '/' + options.TenantId + '/oauth2/v2.0/token',
       },
       scope_delim: ' ',
 

--- a/src/app/base.ts
+++ b/src/app/base.ts
@@ -11,6 +11,7 @@ export interface IExplorerOptions {
     AuthUrl?: string;
     GraphUrl?: string;
     ClientId?: string;
+    TenantId?: string;
     Language?: string;
     RedirectUrl?: string;
     DefaultUserScopes?: string;


### PR DESCRIPTION
## Overview
Added tenant id to the secrets js file so that when running locally you do not have to have a multi-tenanted application. 

## Testing Instructions

* create a new application on portal.azure using all the defaults
* copy the secrets sample to secrets.js
* enter the clientid and tenantid
* run app
* log in