### PR TITLE
Add Analytics.Read scope

### DIFF
--- a/src/app/scopes-dialog/scopes.ts
+++ b/src/app/scopes-dialog/scopes.ts
@@ -45,6 +45,13 @@ export const PermissionScopes: IPermissionScope[] = [
     admin: true,
   },
   {
+    name: "Analytics.Read",
+    description: "Read user analytics",
+    longDescription: "Allows the app to read analytics data such as time spent in activities such as email, meetings, chats and calls.",
+    preview: true,
+    admin: false,
+  },
+  {
     name: "AppCatalog.ReadWrite.All",
     description: "Read and write to all app catalogs",
     longDescription: "Allows the app to create, read, update, and delete apps in the app catalogs.",


### PR DESCRIPTION
Allows the App to read user analytics data.


## Overview

Our goal is to onboard few APIs to MS Graph API. This PR enables testing on beta Graph by adding appropriate scopes.

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* How to test this PR
* Prefer bulleted description
* Start after checking out this branch
* Include any setup required, such as bundling scripts, restarting services, etc.
* Include test case, and expected output