### PR TITLE
Add two new scopes: IdentityRiskEvent.ReadWrite.All and IdentityRisky…

### DIFF
--- a/src/app/scopes-dialog/scopes.ts
+++ b/src/app/scopes-dialog/scopes.ts
@@ -436,9 +436,23 @@ export const PermissionScopes: IPermissionScope[] = [
     admin: true,
   },
   {
+    name: 'IdentityRiskEvent.ReadWrite.All',
+    description: 'Read and write identity risk event information (preview)',
+    longDescription: 'Allows the app to read and write identity risk event information for all users in your organization on behalf of the signed-in user.',
+    preview: true,
+    admin: true,
+  },
+  {
     name: 'IdentityRiskyUser.Read.All',
     description: 'Read identity risky user information (preview)',
     longDescription: 'Allows the app to read identity risky user information for all users in your organization on behalf of the signed-in user.',
+    preview: true,
+    admin: true,
+  },
+  {
+    name: 'IdentityRiskyUser.ReadWrite.All',
+    description: 'Read and write identity risky user information (preview)',
+    longDescription: 'Allows the app to read and write identity risky user information for all users in your organization on behalf of the signed-in user.',
     preview: true,
     admin: true,
   },


### PR DESCRIPTION
Add two new scopes: IdentityRiskEvent.ReadWrite.All and IdentityRiskyUser.ReadWrite.All to Microsoft Graph explorer.

## Overview

Add two new scopes: IdentityRiskEvent.ReadWrite.All and IdentityRiskyUser.ReadWrite.All to Microsoft Graph explorer for the new ~/riskyUsers and ~/riskDetections APIs.

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* How to test this PR
* Prefer bulleted description
* Start after checking out this branch
* Include any setup required, such as bundling scripts, restarting services, etc.
* Include test case, and expected output