### PR TITLE
update mwf to 1.53.1

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -15,8 +15,8 @@
         <script src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-js/1.4.0/js/fabric.min.js"></script>
 
         <!-- MWF -->
-        <link rel="stylesheet" href="https://assets.onestore.ms/cdnfiles/external/mwf/long/v1/v1.20.2/css/mwf-west-european-default.min.css">
-        <script src="https://assets.onestore.ms/cdnfiles/external/mwf/long/v1/v1.20.2/scripts/mwf-main.var.min.js"></script>
+        <link rel="stylesheet" href="https://mwf-service.akamaized.net/mwf/css/bundle/1.53.1/west-european/default/mwf-main.min.css">
+        <script src="https://mwf-service.akamaized.net/mwf/js/bundle/1.53.1/mwf-main.var.min.js"></script>
 
         <link rel="stylesheet" href="custom.css" />
 


### PR DESCRIPTION
## Overview

Updates the references to MWF due to the assets no longer being published to https://assets.onestore.ms (the SSL cert for the domain is also no longer valid but the assets 404 after trusting the invalid cert).

## Notes

Some of the components will likely need some tweaking but this PR at least makes the explorer functional again.

## Testing

run `npm run serve` and view in browser