### PR TITLE
Bug: localisation of non-english loc files

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -144,9 +144,9 @@ export class AppComponent extends GraphExplorerComponent implements OnInit, Afte
         // Show the Microsoft Graph TOU when we load GE.
         AppComponent.messageBarContent = {
             text: this.getLocalisedString('use the Microsoft Graph API') +
-                '<br><br><a href=\'https://aka.ms/msgraphtou\' ' +
+                '<br><br><a class=\'link\' href=\'https://aka.ms/msgraphtou\' ' +
                 'target=\'_blank\'>' + this.getLocalisedString('Terms of use') + '</a><br>' +
-                '<a href=\'https://go.microsoft.com/fwlink/?LinkId=521839\'' +
+                '<a class=\'link\' href=\'https://go.microsoft.com/fwlink/?LinkId=521839\'' +
                 ' target=\'_blank\'>' + this.getLocalisedString('Microsoft Privacy Statement') + '</a>.',
             backgroundClass: 'ms-MessageBar--warning',
             icon: 'none',

--- a/src/custom.css
+++ b/src/custom.css
@@ -125,3 +125,7 @@ api-explorer .c-select-menu>a:after, api-explorer .c-select-menu>button:after {
 *:focus {
     outline: 2px solid #4fc3f7;
 }
+
+.link {
+    color: #006cd8 !important;
+}

--- a/translation_files/de-DE.json
+++ b/translation_files/de-DE.json
@@ -222,11 +222,5 @@
   "replies to a message in channel" : "Antworten auf eine Nachricht im Kanal",
   "reply of a message" : "Antwort auf eine Nachricht",
   "Export": "Exportieren",
-  "Action": "Aktion",
-  "Canary": "Canary",
-  "disable canary" : "disable canary",
-  "using canary" : "You are using the canary version of Graph Explorer. Sign in to make requests",
-  "use the Microsoft Graph API" : "When you use the Microsoft Graph API, you agree to the Microsoft Graph Terms of Use",
-  "Terms of use" : "View the Microsoft Graph Terms of Use",
-  "Microsoft Privacy Statement" : "View the Microsoft Privacy Statement"
+  "Action": "Aktion"
 }

--- a/translation_files/es-ES.json
+++ b/translation_files/es-ES.json
@@ -222,11 +222,5 @@
   "replies to a message in channel" : "respuestas a un mensaje en un canal",
   "reply of a message" : "respuesta de un mensaje",
   "Export": "Exportar",
-  "Action": "Acción",
-  "Canary": "Canary",
-  "disable canary" : "disable canary",
-  "using canary" : "You are using the canary version of Graph Explorer. Sign in to make requests",
-  "use the Microsoft Graph API" : "When you use the Microsoft Graph API, you agree to the Microsoft Graph Terms of Use",
-  "Terms of use" : "View the Microsoft Graph Terms of Use",
-  "Microsoft Privacy Statement" : "View the Microsoft Privacy Statement"
+  "Action": "Acción"
 }

--- a/translation_files/fr-FR.json
+++ b/translation_files/fr-FR.json
@@ -222,11 +222,5 @@
   "replies to a message in channel" : "réponses à un message dans le canal",
   "reply of a message" : "réponse d’un message",
   "Export": "Exporter",
-  "Action": "Action",
-  "Canary": "Canary",
-  "disable canary" : "disable canary",
-  "using canary" : "You are using the canary version of Graph Explorer. Sign in to make requests",
-  "use the Microsoft Graph API" : "When you use the Microsoft Graph API, you agree to the Microsoft Graph Terms of Use",
-  "Terms of use" : "View the Microsoft Graph Terms of Use",
-  "Microsoft Privacy Statement" : "View the Microsoft Privacy Statement"
+  "Action": "Action"
 }

--- a/translation_files/ja-JP.json
+++ b/translation_files/ja-JP.json
@@ -222,11 +222,5 @@
   "replies to a message in channel" : "チャネル内のメッセージへの返信",
   "reply of a message" : "メッセージの返信",
   "Export": "エクスポート",
-  "Action": "アクション",
-  "Canary": "Canary",
-  "disable canary" : "disable canary",
-  "using canary" : "You are using the canary version of Graph Explorer. Sign in to make requests",
-  "use the Microsoft Graph API" : "When you use the Microsoft Graph API, you agree to the Microsoft Graph Terms of Use",
-  "Terms of use" : "View the Microsoft Graph Terms of Use",
-  "Microsoft Privacy Statement" : "View the Microsoft Privacy Statement"
+  "Action": "アクション"
 }

--- a/translation_files/pt-BR.json
+++ b/translation_files/pt-BR.json
@@ -222,11 +222,5 @@
   "replies to a message in channel" : "respostas a uma mensagem em um canal",
   "reply of a message" : "resposta de uma mensagem",
   "Export": "Exportar",
-  "Action": "Ação",
-  "Canary": "Canary",
-  "disable canary" : "disable canary",
-  "using canary" : "You are using the canary version of Graph Explorer. Sign in to make requests",
-  "use the Microsoft Graph API" : "When you use the Microsoft Graph API, you agree to the Microsoft Graph Terms of Use",
-  "Terms of use" : "View the Microsoft Graph Terms of Use",
-  "Microsoft Privacy Statement" : "View the Microsoft Privacy Statement"
+  "Action": "Ação"
 }

--- a/translation_files/ru-RU.json
+++ b/translation_files/ru-RU.json
@@ -222,11 +222,5 @@
   "replies to a message in channel" : "ответы на сообщение в канале",
   "reply of a message" : "ответ на сообщение",
   "Export": "Экспорт",
-  "Action": "Действие",
-  "Canary": "Canary",
-  "disable canary" : "disable canary",
-  "using canary" : "You are using the canary version of Graph Explorer. Sign in to make requests",
-  "use the Microsoft Graph API" : "When you use the Microsoft Graph API, you agree to the Microsoft Graph Terms of Use",
-  "Terms of use" : "View the Microsoft Graph Terms of Use",
-  "Microsoft Privacy Statement" : "View the Microsoft Privacy Statement"
+  "Action": "Действие"
 }

--- a/translation_files/zh-CN.json
+++ b/translation_files/zh-CN.json
@@ -222,11 +222,5 @@
   "replies to a message in channel" : "频道中邮件的答复",
   "reply of a message" : "邮件的答复",
   "Export": "导出",
-  "Action": "操作",
-  "Canary": "Canary",
-  "disable canary" : "disable canary",
-  "using canary" : "You are using the canary version of Graph Explorer. Sign in to make requests",
-  "use the Microsoft Graph API" : "When you use the Microsoft Graph API, you agree to the Microsoft Graph Terms of Use",
-  "Terms of use" : "View the Microsoft Graph Terms of Use",
-  "Microsoft Privacy Statement" : "View the Microsoft Privacy Statement"
+  "Action": "操作"
 }


### PR DESCRIPTION
## Overview

Reverts the changes on the phrases added to the Non-English loc files. They should not be edited. 

It also properly renders the terms of use message

### Demo


![image](https://user-images.githubusercontent.com/4798058/56285681-7ae22700-6120-11e9-8bd3-8ba934893a2b.png)
