### PR TITLE
fix authentication errors

### DIFF
--- a/src/app/authentication/auth.service.ts
+++ b/src/app/authentication/auth.service.ts
@@ -7,7 +7,7 @@ const config = {
         clientId:  ClientId,
     },
     cache: {
-        cacheLocation: 'localStorage',
+        cacheLocation: 'sessionStorage',
         storeAuthStateInCookie: true,
     },
 };
@@ -56,24 +56,7 @@ export async function getTokenSilent(scopes: any = []) {
         }
         return null;
     } catch (error) {
-        if (requiresInteraction(error.errorCode)) {
-            if (loginType === 'POPUP') {
-                try {
-                    const interactionResponse = await app.acquireTokenPopup({scopes: generateUserScopes(listOfScopes)});
-                    if (interactionResponse && interactionResponse.accessToken) {
-                        return interactionResponse;
-                    }
-                } catch (error) {
-                    return null;
-                }
-            } else if (loginType === 'REDIRECT') {
-                try {
-                    app.acquireTokenRedirect({scopes: generateUserScopes(listOfScopes)});
-                } catch (error) {
-                    return null;
-                }
-            }
-        }
+        return null;
     }
 }
 
@@ -155,7 +138,6 @@ function requiresInteraction(errorCode) {
 }
 
 function acquireTokenRedirectCallBack(response) {
-    localStorage.setItem('status', 'authenticated');
     if (response && response.tokenType === 'access_token') {
         return response.accessToken;
     }

--- a/src/app/authentication/auth.ts
+++ b/src/app/authentication/auth.ts
@@ -19,8 +19,8 @@ export function localLogout() {
   // Anonymous users can only GET
   AppComponent.explorerValues.selectedOption = 'GET';
   AppComponent.explorerValues.authentication.user = {};
-  deleteHistoryFromLocalStorage();
   AppComponent.explorerValues.authentication.status = 'anonymous';
+  deleteHistoryFromLocalStorage();
   sessionStorage.clear();
 }
 

--- a/src/app/authentication/auth.ts
+++ b/src/app/authentication/auth.ts
@@ -20,7 +20,7 @@ export function localLogout() {
   AppComponent.explorerValues.selectedOption = 'GET';
   AppComponent.explorerValues.authentication.user = {};
   deleteHistoryFromLocalStorage();
-  localStorage.setItem('status', 'anonymous');
+  AppComponent.explorerValues.authentication.status = 'anonymous';
   sessionStorage.clear();
 }
 
@@ -33,19 +33,19 @@ export async function checkHasValidAuthToken() {
 }
 
 export function isAuthenticated() {
-  const status = localStorage.getItem('status');
+  const status = AppComponent.explorerValues.authentication.status ;
   if (status && status !== 'anonymous') {
     return true;
   }
-  localStorage.setItem('status', 'anonymous');
+  AppComponent.explorerValues.authentication.status = 'anonymous';
   return false;
 }
 
 // tslint:disable-next-line:only-arrow-functions
 (window as any).tokenPlease = async function() {
-  const accessToken = await getTokenSilent();
-  if (accessToken) {
-    return accessToken;
+  const result = await getTokenSilent();
+  if (result) {
+    return result.accessToken;
   } else {
     // tslint:disable-next-line:no-console
     console.log('Please sign in to get your access token');

--- a/src/app/authentication/auth.ts
+++ b/src/app/authentication/auth.ts
@@ -42,12 +42,15 @@ export function isAuthenticated() {
 }
 
 // tslint:disable-next-line:only-arrow-functions
-(window as any).tokenPlease = async function() {
-  const result = await getTokenSilent();
-  if (result) {
-    return result.accessToken;
-  } else {
-    // tslint:disable-next-line:no-console
-    console.log('Please sign in to get your access token');
-  }
+(window as any).tokenPlease = function() {
+  getTokenSilent().then(
+    (result) => {
+      // tslint:disable-next-line:no-console
+      console.log(result.accessToken);
+    },
+    () => {
+      // tslint:disable-next-line:no-console
+      console.log('Please sign in to get your access token');
+    },
+  );
 };

--- a/src/app/authentication/authentication.component.ts
+++ b/src/app/authentication/authentication.component.ts
@@ -11,7 +11,7 @@ import { GraphExplorerComponent } from '../GraphExplorerComponent';
 import { PermissionScopes } from '../scopes-dialog/scopes';
 import { ScopesDialogComponent } from '../scopes-dialog/scopes-dialog.component';
 import { getGraphUrl } from '../util';
-import { localLogout } from './auth';
+import { haveValidAccessToken, localLogout } from './auth';
 import { getScopes, login, logout } from './auth.service';
 
 @Component({
@@ -30,9 +30,14 @@ export class AuthenticationComponent extends GraphExplorerComponent {
   }
 
   public async ngOnInit() {
-    if (this.getAuthenticationStatus() === 'authenticated') {
+    AppComponent.explorerValues.authentication.status = 'authenticating';
+    const valid = await haveValidAccessToken();
+    if (valid) {
+      AppComponent.explorerValues.authentication.status = 'authenticated';
       this.displayUserProfile();
       this.setPermissions();
+    } else {
+      AppComponent.explorerValues.authentication.status = 'anonymous';
     }
   }
 
@@ -41,21 +46,20 @@ export class AuthenticationComponent extends GraphExplorerComponent {
   }
 
   public async login() {
-    localStorage.setItem('status', 'authenticating');
+    AppComponent.explorerValues.authentication.status = 'authenticating';
     this.changeDetectorRef.detectChanges();
     try {
       const loginResponse = await login();
-
       if (loginResponse) {
         this.displayUserProfile();
         this.setPermissions();
         this.changeDetectorRef.detectChanges();
       } else {
-        localStorage.setItem('status', 'anonymous');
+        AppComponent.explorerValues.authentication.status = 'anonymous';
         this.changeDetectorRef.detectChanges();
       }
     } catch (error) {
-      localStorage.setItem('status', 'anonymous');
+      AppComponent.explorerValues.authentication.status = 'anonymous';
       this.changeDetectorRef.detectChanges();
     }
   }
@@ -66,7 +70,7 @@ export class AuthenticationComponent extends GraphExplorerComponent {
   }
 
   public getAuthenticationStatus() {
-    return localStorage.getItem('status');
+    return AppComponent.explorerValues.authentication.status;
   }
 
   public manageScopes() {
@@ -106,7 +110,7 @@ export class AuthenticationComponent extends GraphExplorerComponent {
         AppComponent.explorerValues.authentication.user.profileImageUrl = null;
       }
 
-      localStorage.setItem('status', 'authenticated');
+      AppComponent.explorerValues.authentication.status = 'authenticated';
       this.changeDetectorRef.detectChanges();
     } catch (e) {
       localLogout();

--- a/src/index.html
+++ b/src/index.html
@@ -42,6 +42,12 @@
 
         <script src="systemjs.config.js"></script>
         <script>
+            window.onload = function() {
+                localStorage.removeItem('hello');
+                localStorage.removeItem('msft');
+            };
+</script>
+        <script>
           SystemJS.import('compiler-output/main-jit.js').catch(function(err){ console.error(err); });
         </script>
     </body>


### PR DESCRIPTION
## Overview

* Changes MSAL cache storage from localStorage to sessionStorage (local storage for request history was running out faster)
* Stops saving authentication status in localStorage and instead uses the app component
* Fixes authentication on chrome

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

Edge authenticates but the profile details only show on page waiting for almost 20 second, or reloading the page

## Testing Instructions

* Login on chrome
* Logout
* Login on Edge
* Logout