### PR TITLE
Fixes spinner showing indefinitely

### DIFF
--- a/src/app/authentication/auth.service.ts
+++ b/src/app/authentication/auth.service.ts
@@ -17,11 +17,7 @@ export function logout(userAgentApp: Msal.UserAgentApplication) {
 
 // tslint:disable-next-line: max-line-length
 export async function getTokenSilent(userAgentApp: Msal.UserAgentApplication, scopes: string[]): Promise<Msal.AuthResponse> {
-    try {
-        return await userAgentApp.acquireTokenSilent({ scopes: generateUserScopes(scopes) });
-    } catch (error) {
-        collectLogs(error);
-    }
+ return userAgentApp.acquireTokenSilent({ scopes: generateUserScopes(scopes) });
 }
 
 export async function login(userAgentApp: Msal.UserAgentApplication) {

--- a/src/app/authentication/authentication.component.ts
+++ b/src/app/authentication/authentication.component.ts
@@ -43,7 +43,7 @@ export class AuthenticationComponent extends GraphExplorerComponent {
 
     if (account) {
       AppComponent.explorerValues.authentication.status = 'authenticating';
-      await getTokenSilent(app, defaultScopes)
+      await acquireNewAccessToken(app, defaultScopes)
         .then(this.acquireTokenCallBack)
         .then(this.acquireTokenErrorCallBack);
     }


### PR DESCRIPTION
## Overview

Fixes spinner showing indefinitely on launch.

### Demo

N/A

### Notes

The spinner showed indefinitely because we were getting a token silently with an expired IdToken. This uses the acquireAccessToken method which handles expired IdTokens correctly.

## Testing Instructions

N/A