### PR TITLE
Fix/@microsoft emails

### DIFF
--- a/src/app/authentication/auth.service.ts
+++ b/src/app/authentication/auth.service.ts
@@ -81,13 +81,14 @@ export function generateUserScopes(userScopes = AppComponent.Options.DefaultUser
     return scopes;
 }
 
-function requiresInteraction(errorCode) {
+export function requiresInteraction(errorCode) {
     if (!errorCode || !errorCode.length) {
         return false;
     }
     return errorCode === 'consent_required' ||
         errorCode === 'interaction_required' ||
-        errorCode === 'login_required';
+        errorCode === 'login_required' ||
+        errorCode === 'token_renewal_error';
 }
 
 export function getLoginType() {

--- a/src/app/authentication/authentication.component.ts
+++ b/src/app/authentication/authentication.component.ts
@@ -13,7 +13,7 @@ import { PermissionScopes } from '../scopes-dialog/scopes';
 import { ScopesDialogComponent } from '../scopes-dialog/scopes-dialog.component';
 import { getGraphUrl } from '../util';
 import { localLogout } from './auth';
-import { acquireNewAccessToken, collectLogs, getTokenSilent, login, logout } from './auth.service';
+import { acquireNewAccessToken, collectLogs, login, requiresInteraction } from './auth.service';
 import { app } from './msal-user-agent';
 
 @Component({
@@ -128,7 +128,10 @@ export class AuthenticationComponent extends GraphExplorerComponent {
   private acquireTokenErrorCallBack(error: any): void {
     if (error) {
       collectLogs(error);
-      AppComponent.explorerValues.authentication.status = 'anonymous';
+
+      if (!requiresInteraction(error.errorCode)) {
+        AppComponent.explorerValues.authentication.status = 'anonymous';
+      }
     }
   }
 }

--- a/src/app/authentication/authentication.component.ts
+++ b/src/app/authentication/authentication.component.ts
@@ -129,6 +129,10 @@ export class AuthenticationComponent extends GraphExplorerComponent {
     if (error) {
       collectLogs(error);
 
+      /**
+       * We only want to change the authentication status to anonymous for errors other than those
+       * that require interation from the user.
+       */
       if (!requiresInteraction(error.errorCode)) {
         AppComponent.explorerValues.authentication.status = 'anonymous';
       }

--- a/src/app/scopes-dialog/scopes-dialog.component.ts
+++ b/src/app/scopes-dialog/scopes-dialog.component.ts
@@ -158,14 +158,7 @@ export class ScopesDialogComponent extends GraphExplorerComponent implements Aft
   public async getNewAccessToken() {
     const selectedScopes = PermissionScopes.filter((scope) => scope.requested && !scope.consented)
       .map((scope) => scope.name);
-
-    try {
-      await acquireNewAccessToken(app, selectedScopes).then((response) => {
-        return;
-      });
-    } catch (error) {
-      throw error;
-    }
+    await acquireNewAccessToken(app, selectedScopes);
   }
 
   public static showDialog() { // tslint:disable-line


### PR DESCRIPTION
## Overview

Fixes a bug for user with `@microsoft` emails. There authentication status was changed to anonymous without being truly logged out and were not redirected to the consent page.

### Demo

![image](https://user-images.githubusercontent.com/12011447/62610203-dcb2e080-b90b-11e9-9d12-cb7507b8edbf.png)

### Notes

N/A

## Testing Instructions

* Log in with a @`microsoft email`
* Click on modify permissions
* Select a permission in the scopes dialog and modify it
* Observe that you're redirected to the consent page
