### PR TITLE
Removes app insights

### DIFF
--- a/src/app/authentication/auth.service.ts
+++ b/src/app/authentication/auth.service.ts
@@ -1,14 +1,11 @@
 import * as Msal from 'msal';
 import { AppComponent } from '../app.component';
 
-const { appInsights } = (window as any);
-
 const loginType = getLoginType();
 
 export const collectLogs = (error: any): void => {
-    if (appInsights) {
-        appInsights.trackException(error, 'acquireTokenErrorCallback', {});
-    }
+    // tslint:disable-next-line
+    console.log(error);
 };
 
 export function logout(userAgentApp: Msal.UserAgentApplication) {

--- a/versioned-build.js
+++ b/versioned-build.js
@@ -3,14 +3,6 @@ const thisApp = require('./package');
 
 const dataToAppend = '' +
     `
-
-     var appInsights = window.appInsights || function (a) {
-            function b(a) { c[a] = function () { var b = arguments; c.queue.push(function () { c[a].apply(c, b) }) } } var c = { config: a }, d = document, e = window; setTimeout(function () { var b = d.createElement("script"); b.src = a.url || "https://az416426.vo.msecnd.net/scripts/a/ai.0.js", d.getElementsByTagName("script")[0].parentNode.appendChild(b) }); try { c.cookie = d.cookie } catch (a) { } c.queue = []; for (var f = ["Event", "Exception", "Metric", "PageView", "Trace", "Dependency"]; f.length;)b("track" + f.pop()); if (b("setAuthenticatedUserContext"), b("clearAuthenticatedUserContext"), b("startTrackEvent"), b("stopTrackEvent"), b("startTrackPage"), b("stopTrackPage"), b("flush"), !a.disableExceptionTracking) { f = "onerror", b("_" + f); var g = e[f]; e[f] = function (a, b, d, e, h) { var i = g && g(a, b, d, e, h); return !0 !== i && c["_" + f](a, b, d, e, h), i } } return c
-        }({
-            instrumentationKey: 'a800ae98-f89e-4f96-b491-cf1b8a989bff'
-        });
-        window.appInsights = appInsights, appInsights.queue && 0 === appInsights.queue.length && appInsights.trackPageView();
-
 !function() { return window['appVersion'] = '${thisApp.version}' }()
     `;
 


### PR DESCRIPTION
## Overview

Removes app Insights.

N/A

Optional. Screenshots, `curl` examples, etc.

### Notes

The portal team had to stop using app insights so that they could be GDPR compliant. This is what has formed our basis to get remove app insights for now.

## Testing Instructions

N/A