### PR TITLE
Fix infinte requests for the profile image

### DIFF
--- a/src/app/authentication/authentication.component.html
+++ b/src/app/authentication/authentication.component.html
@@ -29,7 +29,7 @@
 <div *ngIf="getAuthenticationStatus() === 'authenticated'" id="persona-holder">
     <div class="ms-Persona" [class.noPicture]="!authInfo.user.profileImageUrl">
         <div class="ms-Persona-imageArea" *ngIf="authInfo.user.profileImageUrl">
-            <img class="ms-Persona-image" [src]="sanitize(authInfo.user.profileImageUrl)">
+            <img class="ms-Persona-image" [src]="authInfo.user.profileImageUrl">
         </div>
         <div class="ms-Persona-details">
             <div class="ms-Persona-primaryText" id='userDisplayName' *ngIf="authInfo.user.displayName">{{authInfo.user.displayName}}</div>

--- a/src/app/authentication/authentication.component.ts
+++ b/src/app/authentication/authentication.component.ts
@@ -100,7 +100,7 @@ export class AuthenticationComponent extends GraphExplorerComponent {
         const blob = new Blob([userPicture.arrayBuffer()], { type: 'image/jpeg' });
         const imageUrl = window.URL.createObjectURL(blob);
 
-        AppComponent.explorerValues.authentication.user.profileImageUrl = imageUrl;
+        AppComponent.explorerValues.authentication.user.profileImageUrl = this.sanitize(imageUrl) as string;
       } catch (e) {
         collectLogs(e.message);
         AppComponent.explorerValues.authentication.user.profileImageUrl = null;


### PR DESCRIPTION
## Overview

Fixes infinitely looped requests for the profile image
### Demo

#### showing a single request made for the profile picture
![image](https://user-images.githubusercontent.com/12011447/63224901-9b57e600-c1d3-11e9-94b8-fbd97bae8cb4.png)

### Notes

This issue was caused by calling `sanitize` in the `.html` file. Every time the page rendered `sanitze` was called and it's return value set to the `src` attribute. The page renders very so often that it looked like it was making infinitely looped requests.

## Testing Instructions

* Log in with an account that has a profile picture.
* Open your dev tools and click on the **network** tab.
* Observe that there's a single request made for the profile picture.