### PR TITLE
Update scope.ts to use correct scope for Places api: place.read.all

### DIFF
--- a/src/app/scopes-dialog/scopes.ts
+++ b/src/app/scopes-dialog/scopes.ts
@@ -769,7 +769,7 @@ export const PermissionScopes: IPermissionScope[] = [
     admin: true
 },
 {
-    name: 'Places.Read.All',
+    name: 'Place.Read.All',
     description: 'Allows the app to read company places.',
     longDescription: 'Allows the app to read company places (Conf Rooms and Room Lists) for calendar events and other applications.',
     preview: true,


### PR DESCRIPTION
Need to have place.read.all as the accepted scope for calling Exchange places API.
Change by Elias Kaplan


## Overview

Exchange Places API accpts request with scope place.read.all
Previously we have been calling the scope "places.read.all", but the actual name used is w/o the plural s.

Update file to have the correct name

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* How to test this PR
* Prefer bulleted description
* Start after checking out this branch
* Include any setup required, such as bundling scripts, restarting services, etc.
* Include test case, and expected output