### PR TITLE
Add whiteboard metadata api scopes

### DIFF
--- a/src/app/scopes-dialog/scopes.ts
+++ b/src/app/scopes-dialog/scopes.ts
@@ -790,6 +790,20 @@ export const PermissionScopes: IPermissionScope[] = [
     admin: true
 },
 {
+  name: 'Whiteboards.Read',
+  description: 'Read user whiteboards',
+  longDescription: 'Allows the app to read all whiteboards you have access to, and the associated collaborators, on your behalf.',
+  preview: true,
+  admin: false
+},
+{
+  name: 'Whiteboards.ReadWrite',
+  description: 'Manage user whiteboards',
+  longDescription: 'Allows the app to read and modify all whiteboards you have access to, and the associated collaborators, on your behalf.',
+  preview: true,
+  admin: false
+},
+{
     name: 'WorkforceIntegration.Read.All',
     description: 'Read the workforce integrations configured in the tenant',
     longDescription: 'Allows an app to read workforce integrations configured in the tenant on your behalf.',


### PR DESCRIPTION
Add whiteboard metadata api scopes: Whiteboard.Read and Whiteboard.ReadWrite. 
Open PR for scope approval: https://microsoftgraph.visualstudio.com/onboarding/_workitems/edit/3286

Does updating this repo affect both the canary/prod Graph explorer and the PPE Graph explorer?
Also, does the PR for scope approval need to be completed before this PR can be completed?