### PR TITLE
Navigate to intl page

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -8,8 +8,8 @@ import { AfterViewInit, ChangeDetectorRef, Component, OnInit } from '@angular/co
 import { refreshAceEditorsContent } from './ace-utils';
 import { localLogout } from './authentication/auth';
 import {
-    GraphApiVersion, GraphApiVersions, IExplorerOptions, IExplorerValues, IGraphApiCall, IMessage,
-    IMessageBarContent, RequestType,
+  GraphApiVersion, GraphApiVersions, IExplorerOptions, IExplorerValues, IGraphApiCall, IMessage,
+  IMessageBarContent, RequestType,
 } from './base';
 import { initFabricComponents } from './fabric-components';
 import { GenericDialogComponent } from './generic-message-dialog.component';
@@ -23,10 +23,10 @@ declare let mwfAutoInit;
 declare let moment;
 
 @Component({
-    selector: 'api-explorer',
-    providers: [GraphService],
-    templateUrl: './app.component.html',
-    styles: [`
+  selector: 'api-explorer',
+  providers: [GraphService],
+  templateUrl: './app.component.html',
+  styles: [`
   #explorer-main {
       padding-left: 12px;
   }
@@ -39,126 +39,129 @@ declare let moment;
 })
 export class AppComponent extends GraphExplorerComponent implements OnInit, AfterViewInit {
 
-    public static messageBarContent: IMessageBarContent;
-    public static _changeDetectionRef: ChangeDetectorRef; // tslint:disable-line
-    public static message: IMessage;
+  public static messageBarContent: IMessageBarContent;
+  public static _changeDetectionRef: ChangeDetectorRef; // tslint:disable-line
+  public static message: IMessage;
 
-    public static Options: IExplorerOptions = {
-        ClientId: '',
-        Language: 'en-US',
-        // tslint:disable-next-line:max-line-length
-        DefaultUserScopes: ['openid', 'profile', 'User.Read'],
-        AuthUrl: 'https://login.microsoftonline.com',
-        GraphVersions: GraphApiVersions,
-        PathToBuildDir: '',
+  public static Options: IExplorerOptions = {
+    ClientId: '',
+    Language: 'en-US',
+    // tslint:disable-next-line:max-line-length
+    DefaultUserScopes: ['openid', 'profile', 'User.Read'],
+    AuthUrl: 'https://login.microsoftonline.com',
+    GraphVersions: GraphApiVersions,
+    PathToBuildDir: '',
+  };
+
+  public static explorerValues: IExplorerValues = {
+    selectedOption: getParameterByName('method') as RequestType || 'GET',
+    selectedVersion: getParameterByName('version') as GraphApiVersion || 'v1.0',
+    authentication: {
+      user: {},
+    },
+    showImage: false,
+    requestInProgress: false,
+    headers: [],
+    postBody: '',
+  };
+
+  public static requestHistory: IGraphApiCall[] = loadHistoryFromLocalStorage();
+
+  public static addRequestToHistory(request: IGraphApiCall) {
+    AppComponent.requestHistory.splice(0, 0, request); // Add history object to the array
+    saveHistoryToLocalStorage(AppComponent.requestHistory);
+  }
+
+  public static removeRequestFromHistory(request: IGraphApiCall) {
+    const idx = AppComponent.requestHistory.indexOf(request);
+
+    if (idx > -1) {
+      AppComponent.requestHistory.splice(idx, 1);
+    } else {
+      return;
+    }
+    saveHistoryToLocalStorage(AppComponent.requestHistory);
+  }
+
+  public static setMessage(message: IMessage) {
+    AppComponent.message = message;
+    setTimeout(() => { GenericDialogComponent.showDialog(); });
+  }
+
+  constructor(private GraphService: GraphService, private chRef: ChangeDetectorRef) { // tslint:disable-line
+    super();
+    AppComponent._changeDetectionRef = chRef;
+  }
+
+  public ngAfterViewInit(): void {
+    // When clicking on a pivot (request headers/body or response headers/body), notify ACE to update content
+    if (typeof $ !== 'undefined') {
+      $('api-explorer .ms-Pivot-link').on('click', () => {
+        setTimeout(refreshAceEditorsContent, 0);
+      });
+    }
+
+    parseMetadata(this.GraphService, 'v1.0');
+    parseMetadata(this.GraphService, 'beta');
+  }
+
+  public getLocalisedString(message: string): string {
+    const g = new GraphExplorerComponent();
+    return g.getStr(message);
+  }
+
+  public ngOnInit() {
+    for (const key in AppComponent.Options) {
+      if (key in window) {
+        AppComponent.Options[key] = window[key];
+      }
+    }
+
+    const hash = location.hash.substr(1);
+    if (hash.includes('mode')) {
+      const mode = 'canary';
+      localStorage.setItem('GRAPH_MODE', JSON.stringify(mode));
+      localStorage.setItem('GRAPH_URL', 'https://canary.graph.microsoft.com');
+      localLogout();
+    }
+
+    AppComponent.Options.GraphVersions.push('Other');
+
+    initFabricComponents();
+
+    mwfAutoInit.ComponentFactory.create([{
+      component: mwfAutoInit.Drawer,
+    }]);
+
+    moment.locale(AppComponent.Options.Language);
+
+    // Set explorer state that depends on configuration
+    AppComponent.explorerValues.endpointUrl = getGraphUrl()
+      + `/${(getParameterByName('version') || 'v1.0')}/${getParameterByName('request') || 'me/'}`;
+
+    // Show the Microsoft Graph TOU when we load GE.
+    AppComponent.messageBarContent = {
+      // tslint:disable
+      text: this.getLocalisedString('use the Microsoft Graph API') + `
+        <br><br><a class='link' href='https://docs.microsoft.com/${AppComponent.Options.Language}/legal/microsoft-apis/terms-of-use?context=graph/context\' ' +
+        target='_blank'>${this.getLocalisedString('Terms of use')}</a><br>
+        <a class='link' href='https://privacy.microsoft.com/${AppComponent.Options.Language}/privacystatement'
+         target=_blank>${this.getLocalisedString('Microsoft Privacy Statement')}</a>.
+      `,
+      // tslint:enable
+      backgroundClass: 'ms-MessageBar--warning',
+      icon: 'none',
     };
 
-    public static explorerValues: IExplorerValues = {
-        selectedOption: getParameterByName('method') as RequestType || 'GET',
-        selectedVersion: getParameterByName('version') as GraphApiVersion || 'v1.0',
-        authentication: {
-            user: {},
-        },
-        showImage: false,
-        requestInProgress: false,
-        headers: [],
-        postBody: '',
-    };
+    const authStatus = localStorage.getItem('status');
 
-    public static requestHistory: IGraphApiCall[] = loadHistoryFromLocalStorage();
-
-    public static addRequestToHistory(request: IGraphApiCall) {
-        AppComponent.requestHistory.splice(0, 0, request); // Add history object to the array
-        saveHistoryToLocalStorage(AppComponent.requestHistory);
+    switch (authStatus) {
+      case 'authenticated':
+        AppComponent.explorerValues.authentication.status = 'authenticated';
+        break;
+      case 'anonymous':
+        AppComponent.explorerValues.authentication.status = 'anonymous';
+        break;
     }
-
-    public static removeRequestFromHistory(request: IGraphApiCall) {
-        const idx = AppComponent.requestHistory.indexOf(request);
-
-        if (idx > -1) {
-            AppComponent.requestHistory.splice(idx, 1);
-        } else {
-            return;
-        }
-        saveHistoryToLocalStorage(AppComponent.requestHistory);
-    }
-
-    public static setMessage(message: IMessage) {
-        AppComponent.message = message;
-        setTimeout(() => { GenericDialogComponent.showDialog(); });
-    }
-
-    constructor(private GraphService: GraphService, private chRef: ChangeDetectorRef) { // tslint:disable-line
-        super();
-        AppComponent._changeDetectionRef = chRef;
-    }
-
-    public ngAfterViewInit(): void {
-        // When clicking on a pivot (request headers/body or response headers/body), notify ACE to update content
-        if (typeof $ !== 'undefined') {
-            $('api-explorer .ms-Pivot-link').on('click', () => {
-                setTimeout(refreshAceEditorsContent, 0);
-            });
-        }
-
-        parseMetadata(this.GraphService, 'v1.0');
-        parseMetadata(this.GraphService, 'beta');
-    }
-
-    public getLocalisedString(message: string): string {
-        const g = new GraphExplorerComponent();
-        return g.getStr(message);
-    }
-
-    public ngOnInit() {
-        for (const key in AppComponent.Options) {
-            if (key in window) {
-                AppComponent.Options[key] = window[key];
-            }
-        }
-
-        const hash = location.hash.substr(1);
-        if (hash.includes('mode')) {
-            const mode = 'canary';
-            localStorage.setItem('GRAPH_MODE', JSON.stringify(mode));
-            localStorage.setItem('GRAPH_URL', 'https://canary.graph.microsoft.com');
-            localLogout();
-        }
-
-        AppComponent.Options.GraphVersions.push('Other');
-
-        initFabricComponents();
-
-        mwfAutoInit.ComponentFactory.create([{
-            component: mwfAutoInit.Drawer,
-        }]);
-
-        moment.locale(AppComponent.Options.Language);
-
-        // Set explorer state that depends on configuration
-        AppComponent.explorerValues.endpointUrl = getGraphUrl()
-            + `/${(getParameterByName('version') || 'v1.0')}/${getParameterByName('request') || 'me/'}`;
-
-        // Show the Microsoft Graph TOU when we load GE.
-        AppComponent.messageBarContent = {
-            text: this.getLocalisedString('use the Microsoft Graph API') +
-                '<br><br><a class=\'link\' href=\'https://aka.ms/msgraphtou\' ' +
-                'target=\'_blank\'>' + this.getLocalisedString('Terms of use') + '</a><br>' +
-                '<a class=\'link\' href=\'https://go.microsoft.com/fwlink/?LinkId=521839\'' +
-                ' target=\'_blank\'>' + this.getLocalisedString('Microsoft Privacy Statement') + '</a>.',
-            backgroundClass: 'ms-MessageBar--warning',
-            icon: 'none',
-        };
-
-        const authStatus = localStorage.getItem('status');
-
-        switch (authStatus) {
-            case 'authenticated':
-                AppComponent.explorerValues.authentication.status = 'authenticated';
-                break;
-            case 'anonymous':
-                AppComponent.explorerValues.authentication.status = 'anonymous';
-                break;
-        }
-    }
+  }
 }


### PR DESCRIPTION
#### Overview
Navigates user to intl version of web pages when they click on
1. View the Microsoft Graph Terms of Use
2. View the Microsoft Privacy Statement.

#### How to test
1. Launch Graph Explorer
2. Change the language property to `es-ES` in `AppComponent.ts line 48`
3. Click on the translated version of `View the Microsoft Graph Terms of Use`
4. Observe that you're navigated to an intl page

Closes #330 