### PR TITLE
Fixes sample categories toggle label

### DIFF
--- a/src/app/sample-categories/sample-categories-panel.component.css
+++ b/src/app/sample-categories/sample-categories-panel.component.css
@@ -1,12 +1,9 @@
 .category-row {
     margin-bottom: 15px;
     padding: 0 30px;
-}
-
-.category-switch {
-    display: inline-block;
-    float: right;
-    width: 130px;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
 }
 
 div.c-toggle button {

--- a/src/app/sample-categories/sample-categories-panel.component.css
+++ b/src/app/sample-categories/sample-categories-panel.component.css
@@ -6,6 +6,13 @@
     justify-content: space-between;
 }
 
+.toggle-control {
+  display: flex;
+  width: 160px;
+  flex-direction: row;
+  justify-content: space-between;
+}
+
 div.c-toggle button {
     margin-top: 0px;
 }

--- a/src/app/sample-categories/sample-categories-panel.component.html
+++ b/src/app/sample-categories/sample-categories-panel.component.html
@@ -9,9 +9,13 @@
             <div *ngFor="let category of categories" class="category-row" [attr.aria-label]="getStr(category.title)" [attr.id]="getId(category.title)">
                 {{getStr(category.title)}} ({{category.queries.length}})
                 <div class="category-switch">
-                    <div class="c-toggle" (click)="toggleCategory(category)">
-                        <button name="example-1" role="checkbox" [attr.aria-checked]="category.enabled" [attr.aria-labelledby]="getId(category.title)"></button>
-                        <span [attr.data-on-string]="getStr('On')" [attr.data-off-string]="getStr('Off')">{{category.enabled? getStr('On') : getStr('Off')}}</span>
+                    <div class="c-toggle toggle-control" (click)="toggleCategory(category)">
+                        <div>
+                            <button name="example-1" role="checkbox" [attr.aria-checked]="category.enabled" [attr.aria-labelledby]="getId(category.title)"></button>
+                        </div>
+                        <div>
+                            <span [attr.data-on-string]="getStr('On')" [attr.data-off-string]="getStr('Off')">{{category.enabled? getStr('On') : getStr('Off')}}</span>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/src/app/sample-categories/sample-categories-panel.component.html
+++ b/src/app/sample-categories/sample-categories-panel.component.html
@@ -11,7 +11,7 @@
                 <div class="category-switch">
                     <div class="c-toggle" (click)="toggleCategory(category)">
                         <button name="example-1" role="checkbox" [attr.aria-checked]="category.enabled" [attr.aria-labelledby]="getId(category.title)"></button>
-                        <span [attr.data-on-string]="getStr('On')" [attr.data-off-string]="getStr('Off')">{{getStr('On')}}</span>
+                        <span [attr.data-on-string]="getStr('On')" [attr.data-off-string]="getStr('Off')">{{category.enabled? getStr('On') : getStr('Off')}}</span>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Overview

Fixes the toggle label to represent the state of the toggle button.

## Demo

#### Show correct label
<img width="500" alt="Screenshot 2019-09-16 at 1 01 17 PM" src="https://user-images.githubusercontent.com/12011447/64949554-1c150b00-d882-11e9-896b-f98e836bcdcd.png">

#### Fix UI label size breaking UI
![Screenshot 2019-09-16 at 9 17 43 PM](https://user-images.githubusercontent.com/12011447/64982780-a9c71980-d8c7-11e9-8ef4-4038b7d14d80.png)


### Notes

N/A

## Testing Instructions

* Launch Graph Explorer
* Click on `show more samples` in the sidebar
* Observe that the label represents the state of the toggle button

Fixes #352 