### PR TITLE
Add Place.ReadWrite.All to Graph Explorer

### DIFF
--- a/src/app/scopes-dialog/scopes.ts
+++ b/src/app/scopes-dialog/scopes.ts
@@ -832,6 +832,13 @@ export const PermissionScopes: IPermissionScope[] = [
     admin: true
 },
 {
+    name: 'Place.ReadWrite.All',
+    description: 'Allows the app to read and write company places.',
+    longDescription: 'Allows the app to read and write company places (Conf Rooms and Room Lists) for calendar events and other applications.',
+    preview: true,
+    admin: true
+},
+{
     name: 'InformationProtectionPolicy.Read',
     description: 'Read user labels and label policies',
     longDescription: 'Allows an app to read Microsoft Information Protection sensitivity labels and label policy settings for which the user is in scope.',


### PR DESCRIPTION
Add Place.ReadWrite.All to Graph Explorer to allow updating company places from Explorer.


## Overview

Add Place.ReadWrite.All to Graph Explorer to allow updating company places from Explorer.

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* How to test this PR
In Graph explorer logon with a user , tenant admin if possible.
Click on permissions, browse to Place.ReadWrite.All, enable
On accept will show you a pop-up with the scope Place.ReadWrite.All, if is a tenant admin can consent
If not admin, will ask user to get consent from admin.
* Prefer bulleted description
* Start after checking out this branch
* Include any setup required, such as bundling scripts, restarting services, etc.
* Include test case, and expected output