### PR TITLE
Prefixes password with Placeholder password

### DIFF
--- a/sample-queries.csv
+++ b/sample-queries.csv
@@ -22,7 +22,7 @@ Users,POST,create user,/v1.0/users,,https://developer.microsoft.com/en-us/graph/
         ""mailNickname"": ""MelissaD"",
         ""passwordPolicies"": ""DisablePasswordExpiration"",
         ""passwordProfile"": {
-            ""password"": ""{Enter Password}"",
+            ""password"": ""{Placeholder Password}"",
             ""forceChangePasswordNextSignIn"": false
         },
         ""officeLocation"": ""131/1105"",

--- a/src/app/tokens.ts
+++ b/src/app/tokens.ts
@@ -147,7 +147,7 @@ export const Tokens: IToken[] = [
     defaultValue: 'Contoso Home',
   },
   {
-    placeholder: 'Enter Password',
+    placeholder: 'Placeholder Password',
     defaultValue: Guid.create().toString(),
   },
 ];


### PR DESCRIPTION
## Overview

Prefixes Password with placeholder

### Demo

N/A

### Notes

Having the password prefixed with placeholder prevents the scanning tool from flagging this as an issue.

## Testing Instructions

N/A