### PR TITLE
Uses a darker focus outline so as to be MAS 1.4.11 compliant

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -34,7 +34,6 @@ declare let moment;
   sidebar {
       padding: 0px;
   }
-
 `],
 })
 export class AppComponent extends GraphExplorerComponent implements OnInit, AfterViewInit {

--- a/src/custom.css
+++ b/src/custom.css
@@ -133,7 +133,7 @@ api-explorer .c-select-menu>a:after, api-explorer .c-select-menu>button:after {
 }
 
 *:focus {
-    outline: 2px solid #4fc3f7;
+    outline: 2px solid #0877AA;
 }
 
 .link {


### PR DESCRIPTION
## Overview

Fixes [non-text-contrast](https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast.html) accessibility issue.

### Demo

![image](https://user-images.githubusercontent.com/12011447/68651592-c46ce600-0538-11ea-8b07-99f82f5e870d.png)

### Notes

Uses a darker focus outline which increases the contrast ratio.

## Testing Instructions

* Use [Contrast Checker](https://webaim.org/resources/contrastchecker/) to compare the focus outline against the background color.

Closes #365 