### PR TITLE
Enable telemetry only in -tst

### DIFF
--- a/src/app/main-column/main-column.component.ts
+++ b/src/app/main-column/main-column.component.ts
@@ -79,7 +79,11 @@ export class MainColumnComponent extends GraphExplorerComponent implements After
 
     public ngAfterViewInit(): void {
         // Init telemetry
-        telemetry.initialize();
+        const { mscc }: any = window;
+
+        if (mscc && mscc.hasConsent()) {
+            telemetry.initialize();
+        }
 
         // Init httpMethod
         mwfAutoInit.ComponentFactory.create([{

--- a/src/app/main-column/main-column.component.ts
+++ b/src/app/main-column/main-column.component.ts
@@ -79,11 +79,7 @@ export class MainColumnComponent extends GraphExplorerComponent implements After
 
     public ngAfterViewInit(): void {
         // Init telemetry
-        const { mscc }: any = window;
-
-        if (mscc && mscc.hasConsent()) {
-            telemetry.initialize();
-        }
+        telemetry.initialize();
 
         // Init httpMethod
         mwfAutoInit.ComponentFactory.create([{

--- a/src/app/telemetry/event-types.ts
+++ b/src/app/telemetry/event-types.ts
@@ -1,1 +1,3 @@
+// Event names MUST end with the word EVENT
+
 export const RUN_QUERY_EVENT = 'RUN_QUERY_EVENT';

--- a/src/app/telemetry/telemetry.ts
+++ b/src/app/telemetry/telemetry.ts
@@ -32,23 +32,11 @@ class Telemetry implements ITelemetry {
   }
 
   public trackEvent(eventName: string, payload: any) {
-    if (!this.validateEventName(eventName)) {
-      throw new Error('Invalid telemetry event name');
-    }
-
     this.appInsights.trackEvent({ name: eventName }, payload);
   }
 
   public trackException(error: Error, severityLevel: SeverityLevel) {
     this.appInsights.trackException({ error, severityLevel });
-  }
-
-  // A valid event name ends with the word EVENT
-  private validateEventName(eventName: string): boolean {
-    const listOfWords = eventName.split('_');
-    const lastIndex = listOfWords.length - 1;
-    const lastWord = listOfWords[lastIndex];
-    return lastWord === 'EVENT';
   }
 
   private filterFunction(envelope: any): boolean {

--- a/src/app/telemetry/telemetry.ts
+++ b/src/app/telemetry/telemetry.ts
@@ -17,7 +17,7 @@ class Telemetry implements ITelemetry {
     const config = {
       instrumentationKey: this.instrumentationKey,
       disableExceptionTracking: true,
-      disableTelemetry: mscc && mscc.hasConsent() ? false : true,
+      disableTelemetry: this.instrumentationKey ? false : true,
     };
 
     this.appInsights = new ApplicationInsights({ config });

--- a/src/app/telemetry/telemetry.ts
+++ b/src/app/telemetry/telemetry.ts
@@ -12,10 +12,12 @@ class Telemetry implements ITelemetry {
 
   constructor() {
     this.instrumentationKey = (window as any).InstrumentationKey || '';
+    const { mscc } = (window as any);
 
     const config = {
       instrumentationKey: this.instrumentationKey,
       disableExceptionTracking: true,
+      disableTelemetry: mscc.hasConsent() ? false : true,
     };
 
     this.appInsights = new ApplicationInsights({ config });

--- a/src/app/telemetry/telemetry.ts
+++ b/src/app/telemetry/telemetry.ts
@@ -17,7 +17,7 @@ class Telemetry implements ITelemetry {
     const config = {
       instrumentationKey: this.instrumentationKey,
       disableExceptionTracking: true,
-      disableTelemetry: mscc.hasConsent() ? false : true,
+      disableTelemetry: mscc && mscc.hasConsent() ? false : true,
     };
 
     this.appInsights = new ApplicationInsights({ config });

--- a/src/app/telemetry/telemetry.ts
+++ b/src/app/telemetry/telemetry.ts
@@ -40,8 +40,10 @@ class Telemetry implements ITelemetry {
   }
 
   private filterFunction(envelope: any): boolean {
+    // Identifies the source of telemetry collected
     envelope.baseData.name = 'Graph Explorer V3';
 
+    // Removes access token from uri
     const uri = envelope.baseData.uri;
     if (uri) {
       const startOfFragment = uri.indexOf('#');

--- a/src/app/telemetry/telemetry.ts
+++ b/src/app/telemetry/telemetry.ts
@@ -26,6 +26,7 @@ class Telemetry implements ITelemetry {
   public initialize() {
     if (this.instrumentationKey) {
       this.appInsights.loadAppInsights();
+      this.appInsights.addTelemetryInitializer(this.filterFunction);
       this.appInsights.trackPageView();
     }
   }
@@ -48,6 +49,19 @@ class Telemetry implements ITelemetry {
     const lastIndex = listOfWords.length - 1;
     const lastWord = listOfWords[lastIndex];
     return lastWord === 'EVENT';
+  }
+
+  private filterFunction(envelope: any): boolean {
+    envelope.baseData.name = 'Graph Explorer V3';
+
+    const uri = envelope.baseData.uri;
+    if (uri) {
+      const startOfFragment = uri.indexOf('#');
+      const sanitisedUri = uri.substring(0, startOfFragment);
+      envelope.baseData.uri = sanitisedUri;
+    }
+
+    return true;
   }
 }
 


### PR DESCRIPTION
## Overview

This PR: 
1. Initializes telemetry only when a user has consented to us using cookies.
2. Removes run time validity check for event names
3. Removes user information from collected urls.

Closes #409 