### PR TITLE
Adding permissions for M365 Auditing API

### DIFF
--- a/src/app/scopes-dialog/scopes.ts
+++ b/src/app/scopes-dialog/scopes.ts
@@ -1023,5 +1023,12 @@ export const PermissionScopes: IPermissionScope[] = [
     longDescription: 'Allows the app to read and write authentication methods of all users in your organization that the signed-in user has access to. Authentication methods include things like a user\'s phone numbers and Authenticator app settings. This does not allow the app to see secret information like passwords, or to sign-in or otherwise use the authentication methods.',
     preview: true,
     admin: true
+  },
+  {
+    name: 'AuditLog.Create',
+    description: 'Create audit logs for user actions',
+    longDescription: 'Allows the app to create and send audit logs for the actions performed by the signed-in user.',
+    preview: true,
+    admin: true
   }
 ];


### PR DESCRIPTION
Work-item: https://microsoftgraph.visualstudio.com/onboarding/_workitems/edit/4852/

M365 needs to capture various user, admin, system, and policy actions and events to create new or enhance existing operations, security, and compliance-monitoring solutions for the enterprises.
Example, MIP-enabled applications on client devices need to send sensitivity-label-related audit data to a central auditing backend so that administrators can get insights about usage, adoption and efficiency of configured policies for sensitivity labels in their organization, and build advanced reports of their own specific to their needs.


## Overview

Brief description of what this PR does, and why it is needed.

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* How to test this PR
* Prefer bulleted description
* Start after checking out this branch
* Include any setup required, such as bundling scripts, restarting services, etc.
* Include test case, and expected output